### PR TITLE
Add workingDirectory option for publishing a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ jobs:
         environment: 'production'
 ```
 
+Optionally, you can also pass a `workingDirectory` key to the action. This will allow you to specify a subdirectory of the repo to run the Wrangler command from.
+
+```yaml
+jobs:
+  deploy:
+    # ... previous configuration ...
+    steps:
+      uses: cloudflare/wrangler-action@1.0.0
+      with:
+        # ... api key and email ...
+        workingDirectory: 'subfoldername'
+```
+
 ## Use cases
 
 ### Deploying when commits are merged to master

--- a/action.yml
+++ b/action.yml
@@ -15,3 +15,5 @@ inputs:
     required: true
   environment:
     description: "The environment you'd like to publish your Workers project to - must be defined in wrangler.toml"
+  workingDirectory:
+    description: "The relative path which Wrangler commands should be run from"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,11 @@ export CF_API_KEY="$INPUT_APIKEY"
 
 npm i @cloudflare/wrangler -g
 
+if ! [ -z "$INPUT_WORKINGDIRECTORY" ]
+then
+  cd $INPUT_WORKINGDIRECTORY
+fi
+
 if [ -z "$INPUT_ENVIRONMENT" ]
 then
   wrangler publish
@@ -37,3 +42,7 @@ else
   wrangler publish -e "$INPUT_ENVIRONMENT"
 fi
 
+if ! [ -z "$INPUT_WORKINGDIRECTORY" ]
+then
+  cd $HOME
+fi


### PR DESCRIPTION
This addresses https://github.com/cloudflare/wrangler-action/issues/3

Usage is as suggested in the issue:

```
- name: Publish worker one
  uses: cloudflare/wrangler-action@1.0.0
  with:
    apiKey: ${{ secrets.CF_API_KEY }}
    email: ${{ secrets.CF_EMAIL }}
    workingDirectory: 'worker-one'
- name: Publish worker two
  uses: cloudflare/wrangler-action@1.0.0
  with:
    apiKey: ${{ secrets.CF_API_KEY }}
    email: ${{ secrets.CF_EMAIL }}
    workingDirectory: 'worker-two'
```