### PR TITLE
Remove nvm to speed build time

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,19 +3,7 @@
 set -e
 
 export HOME="/github/workspace"
-export NVM_DIR="/github/workspace/nvm"
 export WRANGLER_HOME="/github/workspace"
-
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh | bash
-
-# Comments beginning with "shellcheck" use shellcheck, a shell script linter.
-# The below comments ignore shellcheck linting on the instructions provided
-# by NVM.
-
-# shellcheck source=/dev/null
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-# shellcheck source=/dev/null
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
 
 mkdir -p "$HOME/.wrangler"
 chmod -R 770 "$HOME/.wrangler"


### PR DESCRIPTION
The Dockerfile already pulls the node:12 image, so there's no need for NVM to be downloaded and installed as well. Removing this speeds up the image build time (making Github Actions go faster).

From my testing, removing the un-needed nvm dependency cuts about 15-20 seconds off the Github Actions runtime, with no impact on functionality (as npm and node binaries are already included in the base Docker image, and those work just fine for wrangler).

From looking at the commit history, I think that this installation of NVM step is vestigial from before the node:12 image was used (and an Ubuntu image was being loaded instead).