### PR TITLE
add secrets publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,20 @@ jobs:
         environment: "production"
         wranglerVersion: '1.5.0'
         workingDirectory: 'test'
+  publish_secrets:
+    runs-on: ubuntu-latest
+    name: Publish app with secrets
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish app
+        uses: ./
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          environment: "production"
+          workingDirectory: "test"
+          secrets: |
+            SECRET1
+            SECRET2
+        env:
+          SECRET1: ${{ secrets.SECRET1 }}
+          SECRET2: ${{ secrets.SECRET2 }}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,24 @@ jobs:
         workingDirectory: 'subfoldername'
 ```
 
+[Worker secrets](https://developers.cloudflare.com/workers/tooling/wrangler/secrets/) can be optionally passed as a new line deliminated string of names in `secrets`.  Each secret name must match an environment variable name specified in the `env` attribute.  Creates or replaces the value for the Worker secret using the `wrangler secret put` command.
+
+```yaml
+jobs:
+  deploy:
+    steps:
+      uses: cloudflare/wrangler-action@1.1.0
+      with:
+        apiToken: ${{ secrets.CF_API_TOKEN }}
+        workingDirectory: 'subfoldername'
+        secrets: |
+            SECRET1
+            SECRET2
+      env:
+        SECRET1: ${{ secrets.SECRET1 }}
+        SECRET2: ${{ secrets.SECRET2 }}
+```
+
 ## Use cases
 
 ### Deploying when commits are merged to master

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,11 @@
-name: 'Deploy to Cloudflare Workers with Wrangler'
+name: "Deploy to Cloudflare Workers with Wrangler"
 branding:
-  icon: 'upload-cloud'
-  color: 'orange'
-description: 'Deploy your Cloudflare Workers applications and sites directly from GitHub, using Wrangler'
+  icon: "upload-cloud"
+  color: "orange"
+description: "Deploy your Cloudflare Workers applications and sites directly from GitHub, using Wrangler"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 inputs:
   apiKey:
     description: "(Legacy) Your Cloudflare API Key"
@@ -19,3 +19,6 @@ inputs:
     description: "The relative path which Wrangler commands should be run from"
   wranglerVersion:
     description: "The version of Wrangler you'd like to use to publish your Workers project"
+  secrets:
+    description: "A new line deliminated string of environment variable names that should be configured as Worker secrets"
+    required: false

--- a/test/workers-site/index.js
+++ b/test/workers-site/index.js
@@ -34,6 +34,14 @@ async function handleEvent(event) {
    */
   // options.mapRequestToAsset = handlePrefix(/^\/docs/)
 
+  // Path to test secrets passed through Wrangler Action.  Create SECRET1 and SECRET2 secrets
+  // in the Action repo to something innocuous like "Hello" and "World!".
+  if (url.pathname === "/secret") {
+    let sec1 = (typeof SECRET1 !== 'undefined') ? SECRET1 : ""
+    let sec2 = (typeof SECRET2 !== 'undefined') ? SECRET2 : ""
+    return new Response(`${sec1} ${sec2}`)
+  }
+  
   try {
     if (DEBUG) {
       // customize caching


### PR DESCRIPTION
Proposed solution for publishing worker secrets #19.

### Usage

Worker secrets can be optionally passed as a new line deliminated string of names in `secrets`.  Each secret name must match an environment variable name specified in the `env` attribute.  Creates or replaces the value for the Worker secret using the `wrangler secret put` command.

```yaml
jobs:
  deploy:
    steps:
      uses: cloudflare/wrangler-action@1.1.0
      with:
        apiToken: ${{ secrets.CF_API_TOKEN }}
        workingDirectory: 'subfoldername'
        secrets: |
            SECRET1
            SECRET2
      env:
        SECRET1: ${{ secrets.SECRET1 }}
        SECRET2: ${{ secrets.SECRET2 }}
```

### Design Notes

Blends the usage of both an input field and the env attribute as a means for configuring the Action to perform `wrangler secret put` commands on provided key values.  

The env attribute is well suited for specifying the key value pairs. The addition of the secrets input provides a way for the developer to explicitly specify the list of environment variables names which they'd like configured as worker secrets.

### Testing Note

For testing I updated the workflow along with modifying the test worker to display a few sample secrets configured in the repo on an endpoint “/secret”.  I didn’t include that modification to the test worker in this PR, as you may prefer using console.log and wrangler tail.  I can provide an update to this PR using either method if you'd like.

```javascript
  // Path to test secrets passed through Wrangler Action.  Create SECRET1 and SECRET2 secrets
  // in the Action repo to something innocuous like "Hello" and "World!".
  if (url.pathname === "/secret") {
    let sec1 = (typeof SECRET1 !== 'undefined') ? SECRET1 : ""
    let sec2 = (typeof SECRET2 !== 'undefined') ? SECRET2 : ""
    return new Response(`${sec1} ${sec2}`)
  }
```
