### PR TITLE
Add support for running pre and post commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,11 @@ jobs:
           secrets: |
             SECRET1
             SECRET2
+          preCommands: echo "*** pre command ***"
+          postCommands: |
+            echo "*** post commands ***"
+            wrangler build
+            echo "******"
         env:
           SECRET1: ${{ secrets.SECRET1 }}
           SECRET2: ${{ secrets.SECRET2 }}

--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ jobs:
         SECRET2: ${{ secrets.SECRET2 }}
 ```
 
+If you need to run additional shell commands before or after `wrangler publish`, you can specify them as input to `preCommands` (before publish) or `postCommands` (after publish). These can include additional `wrangler` commands (i.e. `build`, `kv:key put`) or any other commands available inside the `wrangler-action` context.
+
+```yaml
+jobs:
+  deploy:
+    steps:
+      uses: cloudflare/wrangler-action@1.2.0
+      with:
+        apiToken: ${{ secrets.CF_API_TOKEN }}
+        preCommands: echo "*** pre command ***"
+        postCommands: |
+          echo "*** post commands ***"
+          wrangler kv:key put --binding=MY_KV key2 value2
+          echo "******"
+```
+
 ## Use cases
 
 ### Deploying when commits are merged to master

--- a/action.yml
+++ b/action.yml
@@ -22,3 +22,9 @@ inputs:
   secrets:
     description: "A new line deliminated string of environment variable names that should be configured as Worker secrets"
     required: false
+  preCommands:
+    description: "Commands to execute before publishing the Workers project"
+    required: false
+  postCommands:
+    description: "Commands to execute after publishing the Workers project"
+    required: false


### PR DESCRIPTION
If you need to run additional shell commands before or after `wrangler publish`, you can specify them as input to `preCommands` (before publish) or `postCommands` (after publish). These can include additional `wrangler` commands (i.e. `build`, `kv:key put`) or any other commands available inside the `wrangler-action` context.

Sample configuration:

```yaml
jobs:
  deploy:
    steps:
      uses: cloudflare/wrangler-action@1.2.0
      with:
        apiToken: ${{ secrets.CF_API_TOKEN }}
        preCommands: echo "*** pre command ***"
        postCommands: |
          echo "*** post commands ***"
          wrangler kv:key put --binding=MY_KV key2 value2
          echo "******"
```

Closes #25 