### PR TITLE
Add "npm update wrangler" to entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,9 @@ secret_not_found() {
   exit 1
 }
 
+# Make sure we have the most up-to-date versions of Wrangler available
+npm update wrangler
+
 WRANGLER_VERSION=2
 
 # If no Wrangler version is specified install v2.


### PR DESCRIPTION
This fixes an issue where the Github Action will get "stuck" on an outdated version of Wrangler, by making sure that npm has the latest Wrangler versions available to install.

This issue has plagued our Action deployments recently, with wrangler-action attempting to use 2.0.22 which apparently cannot publish properly and the action would run for 360 minutes and time out; even trying to force it with a newer `wranglerVerison` didn't work, as the npm package cache was stuck on 2.0.22 so it didn't attempt to install a newer verison. By updating npm at runtime, it adds a very brief delay (a second or two) but insures that Wrangler is up-to-date.

If someone is reading this and having the same problem, you can work around it without this pull request being merged - just add `preCommands: npm update wrangler` to your action configuration.