### PR TITLE
Upgraded Default Wrangler version to 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.8.1 (Pages Branch bug fix)
+* New `pagesDirectory` input
+    * automatically adds `wrangler pages publish` (inptu command included)
+* New `pagesProject` input
+    * adds `--project-name=<>`to default command (input command included)
+
+* All 2 inputs are for Cloudflare pages, you can deploy to pages without using command.
+    * populating the above inputs will change the use if command function to an extenstion.
+    For example - if you use pagesDirectory and pagesProject along with command. it will exec `wrangler pages publish <dir> <command>`
+    If you use the command input without the 2 pages variables, it will exec `wrangler <command>`
+    Order pagesDirectory > command > pagesProject > pagesBranch > env
+
+* New `pagesBranch` input
+    * workaround for Cloudflare Pages not detecting branches (input command included)
 # 2.0.0 (Breaking update)
 
 ## Additions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 ENV XDG_CONFIG_HOME /github/workspace
 ENV WRANGLER_HOME /github/workspace
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@2.8.1
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -39,7 +39,7 @@ jobs:
   deploy:
     name: Deploy
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -51,7 +51,7 @@ jobs:
   deploy:
     name: Deploy
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiKey: ${{ secrets.CF_API_KEY }}
         email: ${{ secrets.CF_EMAIL }}
@@ -65,7 +65,7 @@ If you need to install a specific version of Wrangler to use for deployment, you
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         wranglerVersion: '1.6.0'
@@ -77,7 +77,7 @@ Optionally, you can also pass a `workingDirectory` key to the action. This will 
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         workingDirectory: 'subfoldername'
@@ -89,7 +89,7 @@ jobs:
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         secrets: |
@@ -106,7 +106,7 @@ If you need to run additional shell commands before or after your command, you c
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         preCommands: echo "*** pre command ***"
@@ -122,7 +122,7 @@ You can use the `command` option to do specific actions such as running `wrangle
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@2.0.0
+      uses: cloudflare/wrangler-action@2.8.1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         command: whoami
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@2.8.1
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -168,11 +168,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@2.8.1
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages publish --project-name=example
+          workingDirectory: 'src'
+          pagesDirectory: 'public'
+          pagesProject: 'exampe'
 ```
 
 ### Deploying on a schedule
@@ -191,7 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish app
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@2.8.1
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -217,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish app
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@2.8.1
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           command: publish --env ${{ github.event.inputs.environment }}
@@ -245,7 +247,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish app
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@2.8.1
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,15 @@ inputs:
   postCommands:
     description: "Commands to execute after publishing the Workers project"
     required: false
+  pagesDirectory:
+    description: "The directory you wish to publish your Pages project. adds: \"pages publish directory\""
+    required: false
+  pagesProject:
+    description: "The Name of the Workers project you wish to publish to"
+    required: false
+  pagesBranch:
+    description: "set to true if Cloudflare fails to recognize thee git branch"
+    required: false
   command:
     description: "The Wrangler command you wish to run. For example: \"publish\" - this will publish your Worker"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,9 +108,6 @@ fi
 
 # Detect GIT branch - cloudflare/wrangler2 issues - #2569 
 BRANCH_OUTPUT=${GITHUB_REF##*/}
-echo "::notice:: branch ${BRANCH_OUTPUT}"
-
-ls -la
 
 # If a working directory is detected as input
 if [ -n "$INPUT_WORKINGDIRECTORY" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,6 +108,9 @@ fi
 
 # Detect GIT branch - cloudflare/wrangler2 issues - #2569 
 BRANCH_OUTPUT=${GITHUB_REF##*/}
+echo "::notice:: branch ${BRANCH_OUTPUT}"
+
+ls -la
 
 # If a working directory is detected as input
 if [ -n "$INPUT_WORKINGDIRECTORY" ]
@@ -135,29 +138,28 @@ done
 # If there's no input command then default to publish otherwise run it
 WRANGLER_CMD="wrangler"
 if [ -n "$INPUT_PAGESDIRECTORY" ]; then
-  WRANGLER_CMD="${WRANGLER_CMD} pages publish ${INPUT_PAGESDIRECTORY}"
+  WRANGLER_CMD="$WRANGLER_CMD pages publish $INPUT_PAGESDIRECTORY"
 fi
 if [ -n "$INPUT_COMMAND" ]; then
   if [ -n "$INPUT_PAGESDIRECTORY" ]; then
     echo "::notice::Since you have specified both pagesDirectory and command, command content will be added after \"wrangler pages publish <dir>\""
   fi
-  WRANGLER_CMD="${WRANGLER_CMD} ${INPUT_COMMAND}"
-elif [ -z "$INPUT_COMMAND" ] && [ -n "$INPUT_PAGESDIRECTORY" ]; then
+  WRANGLER_CMD="$WRANGLER_CMD $INPUT_COMMAND"
+elif [ -z "$INPUT_COMMAND" ] && [ -z "$INPUT_PAGESDIRECTORY" ]; then
   echo "::notice:: Command and pagesDirectory variables were not provided, defaulting to 'publish'"
   if [ -z "$INPUT_ENVIRONMENT" ]; then
-    WRANGLER_CMD="${WRANGLER_CMD } publish"
+    WRANGLER_CMD="$WRANGLER_CMD  publish"
   fi
 fi
 
-if [ -n "$INPUT_PROJECTNAME" ]; then
-  WRANGLER_CMD="${WRANGLER_CMD} --project-name=${INPUT_PROJECTNAME}"
+if [ -n "$INPUT_PAGESPROJECT" ]; then
+  WRANGLER_CMD="$WRANGLER_CMD --project-name=$INPUT_PAGESPROJECT"
 fi
 if [ -n "$INPUT_BRANCHDETECT" ]; then
-  WRANGLER_CMD="${WRANGLER_CMD} --branch==${INPUT_BRANCHDETECT}"
+  WRANGLER_CMD="$WRANGLER_CMD --branch=$INPUT_BRANCHDETECT"
 fi
 if [ -n "$INPUT_ENVIRONMENT" ]; then
-  WRANGLER_CMD="${WRANGLER_CMD} --env ${INPUT_ENVIRONMENT}"
-else
+  WRANGLER_CMD="$WRANGLER_CMD --env $INPUT_ENVIRONMENT"
   echo "::notice::Since you have specified an environment you need to make sure to pass in '--env $INPUT_ENVIRONMENT' to your command."
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,6 @@ export WRANGLER_HOME="/github/workspace"
 mkdir -p "$HOME/.wrangler"
 chmod -R 770 "$HOME/.wrangler"
 
-# Detect GIT branch - cloudflare/wrangler2 issues - #2569 
-BRANCH_OUTPUT=$(git branch)
-
 export API_CREDENTIALS=""
 
 # Used to execute any specified pre and post commands
@@ -108,6 +105,9 @@ then
 else
   echo "Using $API_CREDENTIALS authentication"
 fi
+
+# Detect GIT branch - cloudflare/wrangler2 issues - #2569 
+BRANCH_OUTPUT=${GITHUB_REF##*/}
 
 # If a working directory is detected as input
 if [ -n "$INPUT_WORKINGDIRECTORY" ]


### PR DESCRIPTION
## Upgraded Default Wrangler version to 2.8.1

Added 3 variables 

* New `pagesDirectory` input
    * automatically adds `wrangler pages publish` (inptu command included)
* New `pagesProject` input
    * adds `--project-name=<>`to default command (input command included)

* All 2 inputs are for Cloudflare pages, you can deploy to pages without using command.
    * populating the above inputs will change the use if command function to an extenstion.
    For example - if you use pagesDirectory and pagesProject along with command. it will exec `wrangler pages publish <dir> <command>`
    If you use the command input without the 2 pages variables, it will exec `wrangler <command>`
    Order pagesDirectory > command > pagesProject > pagesBranch > env

* New `pagesBranch` input
    * workaround for Cloudflare Pages deeployment bug (not detecting branches)