### PR TITLE
Support secret:bulk publish using file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
         workingDirectory: 'subfoldername'
 ```
 
-[Worker secrets](https://developers.cloudflare.com/workers/tooling/wrangler/secrets/) can be optionally passed as a new line deliminated string of names in `secrets`.  Each secret name must match an environment variable name specified in the `env` attribute.  Creates or replaces the value for the Worker secret using the `wrangler secret put` command.
+[Worker secrets](https://developers.cloudflare.com/workers/wrangler/commands/#secret) can be optionally passed as a new line deliminated string of names in `secrets`.  Each secret name must match an environment variable name specified in the `env` attribute.  Creates or replaces the value for the Worker secret using the `wrangler secret put` command.
 
 ```yaml
 jobs:
@@ -98,6 +98,18 @@ jobs:
       env:
         SECRET1: ${{ secrets.SECRET1 }}
         SECRET2: ${{ secrets.SECRET2 }}
+```
+
+Alternatively, a JSON file containing secrets in key-value pairs can also be uploaded directly using the `wrangler secret:bulk` command. 
+
+```yaml
+jobs:
+  deploy:
+    steps:
+      uses: cloudflare/wrangler-action@2.1.1
+      with:
+        apiToken: ${{ secrets.CF_API_TOKEN }}
+        secretsFile: 'pathtojsonfile'
 ```
 
 If you need to run additional shell commands before or after your command, you can specify them as input to `preCommands` (before `publish`) or `postCommands` (after `publish`). These can include additional `wrangler` commands (that is, `whoami`, `kv:key put`) or any other commands available inside the `wrangler-action` context.

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   secrets:
     description: "A new line deliminated string of environment variable names that should be configured as Worker secrets"
     required: false
+  secretsFile:
+    description: 'The path to a JSON file containing secrets in key-value pairs that should be configured as Worker secrets'
+    required: false
   preCommands:
     description: "Commands to execute before publishing the Workers project"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,6 +129,23 @@ for SECRET in $INPUT_SECRETS; do
   fi
 done
 
+# If we have bulk secrets file, set them too
+if [ -n "$INPUT_SECRETSFILE" ]
+then
+  # Bulk secrets upload only supported in Wrangler v2 (2.1.1)
+  if [ $WRANGLER_VERSION == 1 ]; then
+    echo "::error::Wrangler v1 does not support bulk secrets upload. You should instead use secret put."
+    exit 1
+  fi
+
+  echo "Uploading secrets from $INPUT_SECRETSFILE"
+  if [ -z "$INPUT_ENVIRONMENT" ]; then
+    wrangler secret:bulk "$INPUT_SECRETSFILE"
+  else
+    wrangler secret:bulk "$INPUT_SECRETSFILE" --env "$INPUT_ENVIRONMENT"
+  fi
+fi
+
 # If there's no input command then default to publish otherwise run it
 if [ -z "$INPUT_COMMAND" ]; then
   echo "::notice:: No command was provided, defaulting to 'publish'"


### PR DESCRIPTION
Changes to add support for the [secret:bulk](https://developers.cloudflare.com/workers/wrangler/commands/#secretbulk) command as part of wrangler v2. 

Related issue - https://github.com/cloudflare/wrangler-action/issues/84

Tested by generating a JSON file from template using 1Password as the vault. Then uploading said file using the action.