### PR TITLE
Additional Error Handling

### DIFF
--- a/.changeset/itchy-buses-grow.md
+++ b/.changeset/itchy-buses-grow.md
@@ -1,0 +1,10 @@
+---
+"wrangler-action": patch
+---
+
+Additional Error Handling
+Previously, we prevented any error logs from propagating too far to prevent leaking of any potentially sensitive information. However, this made it difficult for developers to debug their code.
+
+In this release, we have updated our error handling to allow for more error messaging from pre/post and custom commands. We still discourage the use of these commands for secrets or other sensitive information, but we believe this change will make it easier for developers to debug their code.
+
+Relates to #137

--- a/.changeset/itchy-buses-grow.md
+++ b/.changeset/itchy-buses-grow.md
@@ -2,7 +2,7 @@
 "wrangler-action": patch
 ---
 
-Additional Error Handling
+Added more error logging when a command fails to execute
 Previously, we prevented any error logs from propagating too far to prevent leaking of any potentially sensitive information. However, this made it difficult for developers to debug their code.
 
 In this release, we have updated our error handling to allow for more error messaging from pre/post and custom commands. We still discourage the use of these commands for secrets or other sensitive information, but we believe this change will make it easier for developers to debug their code.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
 	setFailed,
 	endGroup,
 	startGroup,
+	error,
 } from "@actions/core";
 import { execSync, exec } from "node:child_process";
 import { existsSync } from "node:fs";
@@ -114,7 +115,10 @@ async function execCommands(commands: string[], cmdType: string) {
 		});
 	});
 
-	await Promise.all(arrPromises);
+	await Promise.all(arrPromises).catch((result) => {
+		error(`🚨 ${cmdType} Command failed`);
+		setFailed(result);
+	});
 	endGroup();
 }
 
@@ -264,10 +268,16 @@ async function wranglerCommands() {
 				env: process.env,
 			},
 		);
+
 		info(result.stdout);
 		return result;
 	});
-	await Promise.all(arrPromises);
+
+	await Promise.all(arrPromises).catch((result) => {
+		error(`🚨 Command failed`);
+		setFailed(result.stderr);
+	});
+
 	endGroup();
 }
 


### PR DESCRIPTION
Previously, we prevented any error logs from propagating too far to prevent leaking of any potentially sensitive information. However, this made it difficult for developers to debug their code.

In this release, we have updated our error handling to allow for more error messaging from pre/post and custom commands. We still discourage the use of these commands for secrets or other sensitive information, but we believe this change will make it easier for developers to debug their code.

Example of output in `act` local run:
```ts
[...wrangler_action_self_testing]   ❓  ::group::🚀 Executing Wrangler Commands
[...wrangler_action_self_testing]   ❗  ::error::✘ [ERROR] Unknown arguments: dry-run, dryRun, asdf, deploy%0A%0A%0A
[...wrangler_action_self_testing]   ❓  ::endgroup::
```

Relates to #137