### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easy-to-use GitHub Action to use [Wrangler](https://developers.cloudflare.com/wo
 
 - Wrangler v1 is no longer supported.
 - Global API key & Email Auth no longer supported
-- Action version syntax is newly supported. This means e.g. `uses: cloudflare/wrangler-action@v3` and `uses: cloudflare/wrangler-action@v3.x` are both now valid syntax. Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` continues to be supported.
+- Action version syntax is newly supported. This means e.g. `uses: cloudflare/wrangler-action@v3`, `uses: cloudflare/wrangler-action@v3.x`, `uses: cloudflare/wrangler-action@v3.x.x`  and  are both now valid syntax. Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` will no longer be supported, the prefix `v` will be necessary.
 
 [Refer to Changelog for more information](CHANGELOG.md).
 


### PR DESCRIPTION
Due to how Changesets creates tags automatically the previous, non-standard convention, being utilized for tagging versions for this Action will no longer be supported after the underlying `wrangler-action@3.0.1`

What the tagging looks like: 
<img width="691" alt="Screenshot 2023-08-11 at 11 39 45 AM" src="https://github.com/cloudflare/wrangler-action/assets/27247160/33eba9ef-87be-40ea-90b5-adb9d2c65184">
