### PR TITLE
Fix examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easy-to-use GitHub Action to use [Wrangler](https://developers.cloudflare.com/wo
 
 - Wrangler v1 is no longer supported.
 - Global API key & Email Auth no longer supported
-- Action version syntax is newly supported. This means e.g. `uses: cloudflare/wrangler-action@v3`, `uses: cloudflare/wrangler-action@v3.x`, `uses: cloudflare/wrangler-action@v3.x.x`  and  are both now valid syntax. Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` will no longer be supported, the prefix `v` will be necessary.
+- Action version syntax is newly supported. This means e.g. `uses: cloudflare/wrangler-action@v3`, `uses: cloudflare/wrangler-action@v3.x`, and `uses: cloudflare/wrangler-action@v3.x.x` are both now valid syntax. Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` will no longer be supported, the prefix `v` will be necessary.
 
 [Refer to Changelog for more information](CHANGELOG.md).
 
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy
-        uses: cloudflare/wrangler-action@3.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -45,7 +45,7 @@ jobs:
   deploy:
     name: Deploy
     steps:
-      uses: cloudflare/wrangler-action@3.0.0
+      uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -58,7 +58,7 @@ If you need to install a specific version of Wrangler to use for deployment, you
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@3.0.0
+      uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         wranglerVersion: "2.20.0"
@@ -70,7 +70,7 @@ Optionally, you can also pass a `workingDirectory` key to the action. This will 
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@3.0.0
+      uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         workingDirectory: "subfoldername"
@@ -82,7 +82,7 @@ jobs:
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@3.0.0
+      uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         secrets: |
@@ -99,7 +99,7 @@ If you need to run additional shell commands before or after your command, you c
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@3.0.0
+      uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         preCommands: echo "*** pre command ***"
@@ -115,7 +115,7 @@ You can use the `command` option to do specific actions such as running `wrangle
 jobs:
   deploy:
     steps:
-      uses: cloudflare/wrangler-action@3.0.0
+      uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         command: whoami
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy
-        uses: cloudflare/wrangler-action@3.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -161,7 +161,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy
-        uses: cloudflare/wrangler-action@3.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
@@ -184,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy app
-        uses: cloudflare/wrangler-action@3.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
 ```
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy app
-        uses: cloudflare/wrangler-action@3.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           command: deploy --env ${{ github.event.inputs.environment }}
@@ -238,7 +238,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy app
-        uses: cloudflare/wrangler-action@3.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easy-to-use GitHub Action to use [Wrangler](https://developers.cloudflare.com/wo
 
 - Wrangler v1 is no longer supported.
 - Global API key & Email Auth no longer supported
-- Action version syntax is newly supported. This means e.g. `uses: cloudflare/wrangler-action@v3`, `uses: cloudflare/wrangler-action@v3.x`, and `uses: cloudflare/wrangler-action@v3.x.x` are both now valid syntax. Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` will no longer be supported, the prefix `v` will be necessary.
+- Action version syntax is newly supported. This means e.g. `uses: cloudflare/wrangler-action@v3`, `uses: cloudflare/wrangler-action@v3.x`, and `uses: cloudflare/wrangler-action@v3.x.x` are all now valid syntax. Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` is no longer supported -- the prefix `v` is now necessary.
 
 [Refer to Changelog for more information](CHANGELOG.md).
 


### PR DESCRIPTION
Fix the examples in README to use `cloudflare/wrangler-action@v3` instead of `cloudflare/wrangler-action@3.0.0`, because the docs said: 

> Previously supported syntax e.g. `uses: cloudflare/wrangler-action@3.x.x` will no longer be supported, the prefix `v` will be necessary.