### PR TITLE
Refactor error handling to stop execution on errors

### DIFF
--- a/.changeset/stale-spiders-turn.md
+++ b/.changeset/stale-spiders-turn.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Refactored error handling to stop execution when action fails. Previously, the action would continue executing to completion if one of the steps encountered an error. Fixes #160.


### PR DESCRIPTION
Fixes #160

This PR refactors the way errors are propagated through the action when encountered. Previously, the action relied solely on `core.setFailed()` to handle errors, but this only sets the action status while allowing execution to continue. You can see this occur in https://github.com/cloudflare/wrangler-action/actions/runs/5968662403/job/16192935017#step:9:22, where the secret upload step failed, but the action proceeded to deploy the worker anyway.

Now instead of calling `core.setFailed()` at the source of every failure case, we throw errors and catch them at the top level where we then output the error and call `core.setFailed()`.

This PR also:
* tweaks a few error messages to be more descriptive.
* removes a couple of places where the same errors were being handled at multiple levels.
* adds `finally` blocks around some `endGroup()` calls to ensure no groups are left dangling open if an error occurs.