### PR TITLE
add `tag_name` input to Tag & Release Action step of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Tag & Release Action
         if: steps.changesets.outputs.published == 'true'
+        with:
+          tag_name: v${{ fromJSON(steps.changesets.outputs.publishedPackages)[0].version }}
         uses: JasonEtco/build-and-tag-action@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Followup to #159.

We [forgot](https://github.com/cloudflare/wrangler-action/actions/runs/6026367403/job/16349123621) to manually provide the `tag_name` input to the `JasonEtco/build-and-tag-action@v2` action. It previously got the tag name from the `release` event payload, but we're no longer running its workflow on that event.