### PR TITLE
Update action to use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   color: "orange"
 description: "Deploy your Cloudflare projects from GitHub using Wrangler"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.mjs"
 inputs:
   apiToken:

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ branding:
   color: "orange"
 description: "Deploy your Cloudflare projects from GitHub using Wrangler"
 runs:
+  # Possible values: https://github.com/actions/runner/blob/main/src/Runner.Common/Util/NodeUtil.cs#L9
   using: "node20"
   main: "dist/index.mjs"
 inputs:


### PR DESCRIPTION
Action runner [v2.308.0](https://github.com/actions/runner/releases/tag/v2.308.0) added `node20` support. Since everything else (`@types/node`, `node-version` in workflows, etc) in this project is reference `latest` (current `20.x`), I figured the tool itself should also be on `20.x`.

Also for future reference, all possible node values for `using` is in [NodeUtil.cs](https://github.com/actions/runner/blob/main/src/Runner.Common/Util/NodeUtil.cs#L9). I also put it in as a comment in the `action.yml` for easier future reference, but feel free to remove if it feels out of place.