### PR TITLE
ReadMe Improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
 ```
-### "[NOTICE] Since you have specified an environment you need to make sure to pass in '--env dev' to your command."
+### "[NOTICE] Since you have specified an environment you need to make sure to pass in '--env <environment>' to your command."
 
 If you are setting [environment specific parameters](https://developers.cloudflare.com/workers/wrangler/environments/) via the `wrangler.toml` file. You need to ensure the environment parameter is passed to the `action` as well as in the `command` you are executing. This is because other Wrangler commands, such as secret uploads, need to know the environment context as well.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ jobs:
 ```
 ### "[NOTICE] Since you have specified an environment you need to make sure to pass in '--env dev' to your command."
 
-If you are setting [environment specific parameters](https://developers.cloudflare.com/workers/wrangler/environments/) via the `wrangler.toml` file. You need to ensure the environment parameter is passed to the `action` as well as in the `command` you are asking Wrangler to execute. This is becuase other Wrangler, such as secret uploads, need to know the environment context as well.
+If you are setting [environment specific parameters](https://developers.cloudflare.com/workers/wrangler/environments/) via the `wrangler.toml` file. You need to ensure the environment parameter is passed to the `action` as well as in the `command` you are executing. This is because other Wrangler commands, such as secret uploads, need to know the environment context as well.
 
 ```yaml
 on: [push]

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
+          environment: ${{ github.event.inputs.environment }}
           command: deploy --env ${{ github.event.inputs.environment }}
 ```
 
@@ -242,4 +243,24 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
+```
+### "[NOTICE] Since you have specified an environment you need to make sure to pass in '--env dev' to your command."
+
+If you are setting [environment specific parameters](https://developers.cloudflare.com/workers/wrangler/environments/) via the `wrangler.toml` file. You need to ensure the environment parameter is passed to the `action` as well as in the `command` you are asking Wrangler to execute. This is becuase other Wrangler, such as secret uploads, need to know the environment context as well.
+
+```yaml
+on: [push]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy app
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          environment: dev
+          command: deploy --env dev
 ```


### PR DESCRIPTION
Improve the manual workflow example to better highlight how the `environment` parameter should be passed to the actions.

Specifically, to the `action` itself and to the `command` passed to the Wrangler CLI executed by the action.

Also added a troubleshooting example based on the error that shows when you specify the environment via the command, but do not add it against the action. It feels ambiguous, so this should help developers interpret this better.