### PR TITLE
Add bun support

### DIFF
--- a/.changeset/forty-poets-guess.md
+++ b/.changeset/forty-poets-guess.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Added support for Bun as a package manager

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,6 @@ inputs:
     description: "A string of environment variable names, separated by newlines. These will be bound to your Worker using the values of matching environment variables declared in `env` of this workflow."
     required: false
   packageManager:
-    description: "The package manager you'd like to use to install and run wrangler. If not specified, a value will be inferred based on the presence of a lockfile. Valid values: [npm, pnpm, yarn]"
+    description: "The package manager you'd like to use to install and run wrangler. If not specified, a value will be inferred based on the presence of a lockfile. Valid values: [npm, pnpm, yarn, bun]"
     required: false
     default: npm

--- a/src/packageManagers.test.ts
+++ b/src/packageManagers.test.ts
@@ -26,6 +26,14 @@ describe("getPackageManager", () => {
 				  "install": "pnpm add",
 				}
 			`);
+
+		expect(getPackageManager('bun', { workingDirectory: "test/bun" }))
+			.toMatchInlineSnapshot(`
+				{
+				  "exec": "bunx",
+				  "install": "bun i",
+				}
+			`);
 	});
 
 	test("should use npm if no value provided and package-lock.json exists", () => {
@@ -56,6 +64,16 @@ describe("getPackageManager", () => {
 			  "install": "pnpm add",
 			}
 		`);
+	});
+
+	test("should use bun if no value provided and bun.lockb exists", () => {
+		expect(getPackageManager("", { workingDirectory: "test/bun" }))
+			.toMatchInlineSnapshot(`
+			{
+			  "exec": "bunx",
+			  "install": "bun i",
+			}
+			`);
 	});
 
 	test("should use npm if no value provided and no lockfile is present", () => {

--- a/src/packageManagers.ts
+++ b/src/packageManagers.ts
@@ -19,6 +19,10 @@ const PACKAGE_MANAGERS = {
 		install: "pnpm add",
 		exec: "pnpm exec",
 	},
+	bun: {
+		install: "bun i",
+		exec: "bunx"
+	},
 } as const satisfies Readonly<Record<string, PackageManager>>;
 
 type PackageManagerValue = keyof typeof PACKAGE_MANAGERS;
@@ -34,6 +38,9 @@ function detectPackageManager(
 	}
 	if (existsSync(path.join(workingDirectory, "pnpm-lock.yaml"))) {
 		return "pnpm";
+	}
+	if (existsSync(path.join(workingDirectory, "bun.lockb"))) {
+		return "bun";
 	}
 	return null;
 }

--- a/test/bun/index.ts
+++ b/test/bun/index.ts
@@ -1,0 +1,26 @@
+type Env = {
+	SECRET1?: string;
+	SECRET2?: string;
+};
+
+export default {
+	fetch(request: Request, env: Env) {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/secret-health-check") {
+			const { SECRET1, SECRET2 } = env;
+
+			if (SECRET1 !== "SECRET_1_VALUE" || SECRET2 !== "SECRET_2_VALUE") {
+				throw new Error("SECRET1 or SECRET2 is not defined");
+			}
+
+			return new Response("OK");
+		}
+
+		// @ts-expect-error
+		return Response.json({
+			...request,
+			headers: Object.fromEntries(request.headers),
+		});
+	},
+};

--- a/test/bun/package.json
+++ b/test/bun/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "wrangler-action-npm-test",
+  "name": "wrangler-action-bun-test",
 }

--- a/test/bun/package.json
+++ b/test/bun/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "wrangler-action-npm-test",
+}

--- a/test/bun/wrangler.toml
+++ b/test/bun/wrangler.toml
@@ -1,0 +1,4 @@
+name = "wrangler-action-test"
+main = "./index.ts"
+compatibility_date = "2023-07-07"
+workers_dev = true


### PR DESCRIPTION
This PR adds [Bun](https://bun.sh/) support and closes #187.

I wrote the PR before I read the contributing guidelines (sorry) and did not make an issue before I started working. As such, if you decline this it's not a big deal.

However, worth noting, it does work and I can deploy my website to CF pages with this.