### PR TITLE
Use npm as fallback if no `packageManager` specified

### DIFF
--- a/.changeset/slimy-cameras-play.md
+++ b/.changeset/slimy-cameras-play.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Fixed action failure when no `packageManager` specified and no lockfile is found. The action now falls back to using npm.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,14 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --dry-run
 
+      - name: Support unspecified packageManager with no lockfile
+        uses: ./
+        with:
+          workingDirectory: "./test/empty"
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --dry-run
+
       - name: Support npm package manager
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,6 @@ inputs:
     description: "A string of environment variable names, separated by newlines. These will be bound to your Worker using the values of matching environment variables declared in `env` of this workflow."
     required: false
   packageManager:
-    description: "The name of the package manager to install and run wrangler. If not provided, it will be detected via the lock file. Valid values: [npm, pnpm, yarn]"
+    description: "The package manager you'd like to use to install and run wrangler. If not specified, a value will be inferred based on the presence of a lockfile. Valid values: [npm, pnpm, yarn]"
     required: false
+    default: npm

--- a/src/packageManagers.test.ts
+++ b/src/packageManagers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { getPackageManager } from "./packageManagers";
+
+describe("getPackageManager", () => {
+	test("should use provided value instead of inferring from lockfile", () => {
+		expect(getPackageManager("npm", { workingDirectory: "test/npm" }))
+			.toMatchInlineSnapshot(`
+				{
+				  "exec": "npx",
+				  "install": "npm i",
+				}
+			`);
+
+		expect(getPackageManager("yarn", { workingDirectory: "test/npm" }))
+			.toMatchInlineSnapshot(`
+			{
+			  "exec": "yarn",
+			  "install": "yarn add",
+			}
+		`);
+
+		expect(getPackageManager("pnpm", { workingDirectory: "test/npm" }))
+			.toMatchInlineSnapshot(`
+				{
+				  "exec": "pnpm exec",
+				  "install": "pnpm add",
+				}
+			`);
+	});
+
+	test("should use npm if no value provided and package-lock.json exists", () => {
+		expect(getPackageManager("", { workingDirectory: "test/npm" }))
+			.toMatchInlineSnapshot(`
+			{
+			  "exec": "npx",
+			  "install": "npm i",
+			}
+		`);
+	});
+
+	test("should use yarn if no value provided and yarn.lock exists", () => {
+		expect(getPackageManager("", { workingDirectory: "test/yarn" }))
+			.toMatchInlineSnapshot(`
+			{
+			  "exec": "yarn",
+			  "install": "yarn add",
+			}
+		`);
+	});
+
+	test("should use pnpm if no value provided and pnpm-lock.yaml exists", () => {
+		expect(getPackageManager("", { workingDirectory: "test/pnpm" }))
+			.toMatchInlineSnapshot(`
+			{
+			  "exec": "pnpm exec",
+			  "install": "pnpm add",
+			}
+		`);
+	});
+
+	test("should use npm if no value provided and no lockfile is present", () => {
+		expect(getPackageManager("", { workingDirectory: "test/empty" }))
+			.toMatchInlineSnapshot(`
+			{
+			  "exec": "npx",
+			  "install": "npm i",
+			}
+		`);
+	});
+
+	test("should throw if an invalid value is provided", () => {
+		expect(() =>
+			getPackageManager("cargo", { workingDirectory: "test/npm" }),
+		).toThrowError();
+	});
+});

--- a/src/packageManagers.ts
+++ b/src/packageManagers.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
+interface PackageManager {
+	install: string;
+	exec: string;
+}
+
+const PACKAGE_MANAGERS = {
+	npm: {
+		install: "npm i",
+		exec: "npx",
+	},
+	yarn: {
+		install: "yarn add",
+		exec: "yarn",
+	},
+	pnpm: {
+		install: "pnpm add",
+		exec: "pnpm exec",
+	},
+} as const satisfies Readonly<Record<string, PackageManager>>;
+
+type PackageManagerValue = keyof typeof PACKAGE_MANAGERS;
+
+function detectPackageManager(
+	workingDirectory = ".",
+): PackageManagerValue | null {
+	if (existsSync(path.join(workingDirectory, "package-lock.json"))) {
+		return "npm";
+	}
+	if (existsSync(path.join(workingDirectory, "yarn.lock"))) {
+		return "yarn";
+	}
+	if (existsSync(path.join(workingDirectory, "pnpm-lock.yaml"))) {
+		return "pnpm";
+	}
+	return null;
+}
+
+function assertValidPackageManagerValue(
+	name: string,
+): asserts name is PackageManagerValue | "" {
+	if (name && !Object.keys(PACKAGE_MANAGERS).includes(name)) {
+		throw new TypeError(
+			`invalid value provided for "packageManager": ${name}
+	Value must be one of: [${Object.keys(PACKAGE_MANAGERS).join(", ")}]`,
+		);
+	}
+}
+
+export function getPackageManager(
+	name: string,
+	{ workingDirectory = "." }: { workingDirectory?: string } = {},
+) {
+	assertValidPackageManagerValue(name);
+
+	return PACKAGE_MANAGERS[
+		name || detectPackageManager(workingDirectory) || "npm"
+	];
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,11 +1,6 @@
 import path from "node:path";
 import { describe, expect, test } from "vitest";
-import {
-	checkWorkingDirectory,
-	detectPackageManager,
-	isValidPackageManager,
-	semverCompare,
-} from "./utils";
+import { checkWorkingDirectory, semverCompare } from "./utils";
 
 describe("semverCompare", () => {
 	test("should return false if the second argument is equal to the first argument", () => {
@@ -34,35 +29,4 @@ describe("checkWorkingDirectory", () => {
 			'"Directory /does/not/exist does not exist."',
 		);
 	});
-});
-
-describe("detectPackageManager", () => {
-	test("should return name of package manager for current workspace", () => {
-		expect(detectPackageManager()).toBe("npm");
-	});
-
-	test("should return npm if package-lock.json exists", () => {
-		expect(detectPackageManager("test/npm")).toBe("npm");
-	});
-
-	test("should return yarn if yarn.lock exists", () => {
-		expect(detectPackageManager("test/yarn")).toBe("yarn");
-	});
-
-	test("should return pnpm if pnpm-lock.yaml exists", () => {
-		expect(detectPackageManager("test/pnpm")).toBe("pnpm");
-	});
-
-	test("should return null if no package manager is detected", () => {
-		expect(detectPackageManager("test/empty")).toBe(null);
-	});
-});
-
-test("isValidPackageManager", () => {
-	expect(isValidPackageManager("npm")).toBe(true);
-	expect(isValidPackageManager("pnpm")).toBe(true);
-	expect(isValidPackageManager("yarn")).toBe(true);
-
-	expect(isValidPackageManager("")).toBe(false);
-	expect(isValidPackageManager("ppnpm")).toBe(false);
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,24 +29,3 @@ export function checkWorkingDirectory(workingDirectory = ".") {
 		throw new Error(`Directory ${workingDirectory} does not exist.`);
 	}
 }
-
-export type PackageManager = "npm" | "yarn" | "pnpm";
-
-export function detectPackageManager(
-	workingDirectory = ".",
-): PackageManager | null {
-	if (existsSync(path.join(workingDirectory, "package-lock.json"))) {
-		return "npm";
-	}
-	if (existsSync(path.join(workingDirectory, "yarn.lock"))) {
-		return "yarn";
-	}
-	if (existsSync(path.join(workingDirectory, "pnpm-lock.yaml"))) {
-		return "pnpm";
-	}
-	return null;
-}
-
-export function isValidPackageManager(name: string): name is PackageManager {
-	return name === "npm" || name === "yarn" || name === "pnpm";
-}


### PR DESCRIPTION
Fixes #180

#173 added a new `packageManager` input to allow users to *optionally* specify which package manager they'd like to use when running the action. If the value isn't specified, it attempts to infer the appropriate package manager based on the presence of a lockfile. However, if no lockfile is found it throws an error. This was an inadvertent breaking change.

Instead of throwing an error when the input isn't specified and no lockfile is found, we should now fallback to the previous behavior of using npm. Specifying an unsupported package manager, however, throws an error.

This PR also refactors the package manager logic and tests into its own module.