### PR TITLE
Don't set `packageManager` default via action.yml

### DIFF
--- a/.changeset/dirty-poets-swim.md
+++ b/.changeset/dirty-poets-swim.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Fixed the package manager not being inferred based on lockfile when the `packageManager` input isn't set.

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,5 @@ inputs:
     description: "A string of environment variable names, separated by newlines. These will be bound to your Worker using the values of matching environment variables declared in `env` of this workflow."
     required: false
   packageManager:
-    description: "The package manager you'd like to use to install and run wrangler. If not specified, a value will be inferred based on the presence of a lockfile. Valid values: [npm, pnpm, yarn, bun]"
+    description: "The package manager you'd like to use to install and run wrangler. If not specified, the preferred package manager will be inferred based on the presence of a lockfile or fallback to using npm if no lockfile is found. Valid values are `npm` | `pnpm` | `yarn` | `bun`."
     required: false
-    default: npm

--- a/src/packageManagers.test.ts
+++ b/src/packageManagers.test.ts
@@ -27,7 +27,7 @@ describe("getPackageManager", () => {
 				}
 			`);
 
-		expect(getPackageManager('bun', { workingDirectory: "test/bun" }))
+		expect(getPackageManager("bun", { workingDirectory: "test/bun" }))
 			.toMatchInlineSnapshot(`
 				{
 				  "exec": "bunx",

--- a/src/packageManagers.ts
+++ b/src/packageManagers.ts
@@ -21,7 +21,7 @@ const PACKAGE_MANAGERS = {
 	},
 	bun: {
 		install: "bun i",
-		exec: "bunx"
+		exec: "bunx",
 	},
 } as const satisfies Readonly<Record<string, PackageManager>>;
 

--- a/test/bun/package.json
+++ b/test/bun/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "wrangler-action-bun-test",
+	"name": "wrangler-action-bun-test"
 }


### PR DESCRIPTION
In #190 I set `default: npm` in [action.yml](https://github.com/cloudflare/wrangler-action/pull/190/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R47), not realizing this sets the actual input value when it's not provided explicitly (as opposed to just serving as documentation) 🤦🏻‍♂️. This prevented [lockfile inference](https://github.com/cloudflare/wrangler-action/pull/190/files#diff-06a2cb031ff1828e1a5a18c28165d5337828e0fba051b5a4c9569056009c096aR59) from ever happening, since the `packageManager` value would never be empty.

This PR removes the default value, allowing the lockfile inference to happen before ultimately falling back to `"npm"`.