### PR TITLE
Add missing licenses to dummy test packages

### DIFF
--- a/test/base/package.json
+++ b/test/base/package.json
@@ -1,3 +1,4 @@
 {
-	"name": "wrangler-action-test"
+	"name": "wrangler-action-test",
+	"license": "MIT"
 }

--- a/test/base/package.json
+++ b/test/base/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "wrangler-action-test",
-	"license": "MIT"
+	"license": "MIT",
+	"private": true
 }

--- a/test/bun/package.json
+++ b/test/bun/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "wrangler-action-bun-test",
-	"license": "MIT"
+	"license": "MIT",
+	"private": true
 }

--- a/test/bun/package.json
+++ b/test/bun/package.json
@@ -1,3 +1,4 @@
 {
-	"name": "wrangler-action-bun-test"
+	"name": "wrangler-action-bun-test",
+	"license": "MIT"
 }

--- a/test/empty/package.json
+++ b/test/empty/package.json
@@ -1,3 +1,4 @@
 {
-	"name": "wrangler-action-detect-package-manager-test"
+	"name": "wrangler-action-detect-package-manager-test",
+	"license": "MIT"
 }

--- a/test/empty/package.json
+++ b/test/empty/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "wrangler-action-detect-package-manager-test",
-	"license": "MIT"
+	"license": "MIT",
+	"private": true
 }

--- a/test/environment/package.json
+++ b/test/environment/package.json
@@ -1,3 +1,4 @@
 {
-	"name": "wrangler-action-environment-test"
+	"name": "wrangler-action-environment-test",
+	"license": "MIT"
 }

--- a/test/environment/package.json
+++ b/test/environment/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "wrangler-action-environment-test",
-	"license": "MIT"
+	"license": "MIT",
+	"private": true
 }

--- a/test/pnpm/package.json
+++ b/test/pnpm/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "wrangler-action-pnpm-test",
-	"license": "MIT"
+	"license": "MIT",
+	"private": true
 }

--- a/test/pnpm/package.json
+++ b/test/pnpm/package.json
@@ -1,3 +1,4 @@
 {
-	"name": "wrangler-action-pnpm-test"
+	"name": "wrangler-action-pnpm-test",
+	"license": "MIT"
 }

--- a/test/yarn/package.json
+++ b/test/yarn/package.json
@@ -1,3 +1,4 @@
 {
-	"name": "wrangler-action-yarn-test"
+	"name": "wrangler-action-yarn-test",
+	"license": "MIT"
 }

--- a/test/yarn/package.json
+++ b/test/yarn/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "wrangler-action-yarn-test",
-	"license": "MIT"
+	"license": "MIT",
+	"private": true
 }


### PR DESCRIPTION
This is mostly to prevent yarn from raising a [warning](https://github.com/cloudflare/wrangler-action/actions/runs/6483917006/job/17606557543#step:20:28) during our test runs.