### PR TITLE
Don't attempt to publish when there's no pending release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
Currently our release process is kicked off whenever a PR is merged and there are no changesets within the `.changeset` directory. Typically this happens when we intend to publish a release, just after we merge a "Version Packages" PR which removes the changesets and adds the entries to our changelog.

However, this also means that merging any PR without user-facing changes during the period after we've made a release will trigger another release (which luckily fails because the created tag already exists on the remote. See #184).

This change avoids that scenario by fetching tags when checking out the repo. Now when `npx changeset tag` runs, it will see that the tag already exists and skip creating it (`🦋  Skipping tag (already exists):  v3.3.2`). The `git push --tags` step will no longer throw an error (`Everything up-to-date`). And lastly, the publish step won't get triggered because the output from `npx changeset tag` doesn't contain the text `New tag:`. The action should just finish successfully with nothing to left do.

Fixes #184