### PR TITLE
fix: detect pnpm-workspace.yml and append -w when installing wrangler

### DIFF
--- a/src/packageManagers.test.ts
+++ b/src/packageManagers.test.ts
@@ -27,6 +27,15 @@ describe("getPackageManager", () => {
 				}
 			`);
 
+		expect(
+			getPackageManager("pnpm-workspace", { workingDirectory: "test/npm" }),
+		).toMatchInlineSnapshot(`
+				{
+				  "exec": "pnpm exec",
+				  "install": "pnpm add -w",
+				}
+			`);
+
 		expect(getPackageManager("bun", { workingDirectory: "test/bun" }))
 			.toMatchInlineSnapshot(`
 				{

--- a/src/packageManagers.ts
+++ b/src/packageManagers.ts
@@ -19,6 +19,10 @@ const PACKAGE_MANAGERS = {
 		install: "pnpm add",
 		exec: "pnpm exec",
 	},
+	"pnpm-workspace": {
+		install: "pnpm add -w",
+		exec: "pnpm exec",
+	},
 	bun: {
 		install: "bun i",
 		exec: "bunx",
@@ -37,6 +41,10 @@ function detectPackageManager(
 		return "yarn";
 	}
 	if (existsSync(path.join(workingDirectory, "pnpm-lock.yaml"))) {
+		if (existsSync(path.join(workingDirectory, "pnpm-workspace.yaml"))) {
+			// if this is a PNPM workspace, we must use the -w flag when installing wrangler or else it will error with ERR_PNPM_ADDING_TO_ROOT
+			return "pnpm-workspace";
+		}
 		return "pnpm";
 	}
 	if (existsSync(path.join(workingDirectory, "bun.lockb"))) {

--- a/test/pnpm-workspace/index.ts
+++ b/test/pnpm-workspace/index.ts
@@ -1,0 +1,26 @@
+type Env = {
+	SECRET1?: string;
+	SECRET2?: string;
+};
+
+export default {
+	fetch(request: Request, env: Env) {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/secret-health-check") {
+			const { SECRET1, SECRET2 } = env;
+
+			if (SECRET1 !== "SECRET_1_VALUE" || SECRET2 !== "SECRET_2_VALUE") {
+				throw new Error("SECRET1 or SECRET2 is not defined");
+			}
+
+			return new Response("OK");
+		}
+
+		// @ts-expect-error
+		return Response.json({
+			...request,
+			headers: Object.fromEntries(request.headers),
+		});
+	},
+};

--- a/test/pnpm-workspace/package.json
+++ b/test/pnpm-workspace/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "wrangler-action-pnpm-workspace-test",
+	"license": "MIT",
+	"private": true
+}

--- a/test/pnpm-workspace/pkg-a/package.json
+++ b/test/pnpm-workspace/pkg-a/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "wrangler-action-pnpm-workspace-test-pkg-a",
+	"license": "MIT",
+	"private": true
+}

--- a/test/pnpm-workspace/pnpm-lock.yaml
+++ b/test/pnpm-workspace/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/test/pnpm-workspace/pnpm-workspace.yml
+++ b/test/pnpm-workspace/pnpm-workspace.yml
@@ -1,0 +1,3 @@
+# https://pnpm.io/pnpm-workspace_yaml
+packages:
+  - pkg-a

--- a/test/pnpm-workspace/wrangler.toml
+++ b/test/pnpm-workspace/wrangler.toml
@@ -1,0 +1,4 @@
+name = "wrangler-action-test"
+main = "./index.ts"
+compatibility_date = "2023-07-07"
+workers_dev = true


### PR DESCRIPTION
The wrangler-action does not currently support pnpm workspaces. 

See: https://github.com/cloudflare/wrangler-action/issues/181#issuecomment-1765527537

It fails with:
```
📥 Installing Wrangler
  /home/runner/setup-pnpm/node_modules/.bin/pnpm add wrangler@* -w
   ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.
Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
Error: 🚨 Action failed
```

This change detects a pnpm workspace by also looking for `pnpm-workspace.yml` file and then selects an install script that appends `-w`