### PR TITLE
fix: semver comparison

### DIFF
--- a/.changeset/weak-lobsters-march.md
+++ b/.changeset/weak-lobsters-march.md
@@ -1,0 +1,9 @@
+---
+"wrangler-action": patch
+---
+
+Fixes issues with semver comparison, where version parts were treated lexicographically instead of numerically.
+
+Bulk secret uploading was introduced in wrangler `3.4.0`, and this action tries to check if the version used is greater than `3.4.0`, and then if so, using the new bulk secret API which is faster. Due to a bug in the semver comparison, `3.19.0` was being considered less than `3.4.0`, and then using an older and slower method for uploading secrets.
+
+Now the semver comparison is fixed, the faster bulk method is used for uploading secrets when available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,32 +1,33 @@
 {
 	"name": "wrangler-action",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.3.1",
+			"version": "3.3.2",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
-				"@actions/core": "^1.10.0",
+				"@actions/core": "^1.10.1",
 				"@actions/exec": "^1.1.1"
 			},
 			"devDependencies": {
 				"@changesets/changelog-github": "^0.4.8",
 				"@changesets/cli": "^2.26.2",
-				"@cloudflare/workers-types": "^4.20230814.0",
-				"@types/node": "^20.5.0",
-				"@vercel/ncc": "^0.36.1",
-				"prettier": "^3.0.1",
-				"typescript": "^5.1.6",
-				"vitest": "^0.34.1"
+				"@cloudflare/workers-types": "^4.20231121.0",
+				"@types/node": "^20.10.4",
+				"@vercel/ncc": "^0.38.1",
+				"prettier": "^3.1.0",
+				"semver": "^7.5.4",
+				"typescript": "^5.3.3",
+				"vitest": "^1.0.3"
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+			"integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
 			"dependencies": {
 				"@actions/http-client": "^2.0.1",
 				"uuid": "^8.3.2"
@@ -41,11 +42,12 @@
 			}
 		},
 		"node_modules/@actions/http-client": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
-			"integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
+			"integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
 			"dependencies": {
-				"tunnel": "^0.0.6"
+				"tunnel": "^0.0.6",
+				"undici": "^5.25.4"
 			}
 		},
 		"node_modules/@actions/io": {
@@ -54,34 +56,35 @@
 			"integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -89,28 +92,28 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-			"integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
+			"integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
 			"dev": true,
 			"dependencies": {
-				"regenerator-runtime": "^0.13.11"
+				"regenerator-runtime": "^0.14.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@changesets/apply-release-plan": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
-			"integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.0.tgz",
+			"integrity": "sha512-vfi69JR416qC9hWmFGSxj7N6wA5J222XNBmezSVATPWDVPIF7gkd4d8CpbEbXmRWbVrkoli3oerGS6dcL/BGsQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/config": "^2.3.1",
-				"@changesets/get-version-range-type": "^0.3.2",
-				"@changesets/git": "^2.0.0",
-				"@changesets/types": "^5.2.1",
+				"@changesets/config": "^3.0.0",
+				"@changesets/get-version-range-type": "^0.4.0",
+				"@changesets/git": "^3.0.0",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"detect-indent": "^6.0.0",
 				"fs-extra": "^7.0.1",
@@ -120,6 +123,12 @@
 				"resolve-from": "^5.0.0",
 				"semver": "^7.5.3"
 			}
+		},
+		"node_modules/@changesets/apply-release-plan/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
 		},
 		"node_modules/@changesets/apply-release-plan/node_modules/prettier": {
 			"version": "2.8.8",
@@ -137,27 +146,39 @@
 			}
 		},
 		"node_modules/@changesets/assemble-release-plan": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
-			"integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.0.tgz",
+			"integrity": "sha512-4QG7NuisAjisbW4hkLCmGW2lRYdPrKzro+fCtZaILX+3zdUELSvYjpL4GTv0E4aM9Mef3PuIQp89VmHJ4y2bfw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/errors": "^0.1.4",
-				"@changesets/get-dependents-graph": "^1.3.6",
-				"@changesets/types": "^5.2.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/get-dependents-graph": "^2.0.0",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"semver": "^7.5.3"
 			}
 		},
+		"node_modules/@changesets/assemble-release-plan/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/changelog-git": {
-			"version": "0.1.14",
-			"resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
-			"integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.0.tgz",
+			"integrity": "sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==",
 			"dev": true,
 			"dependencies": {
-				"@changesets/types": "^5.2.1"
+				"@changesets/types": "^6.0.0"
 			}
+		},
+		"node_modules/@changesets/changelog-git/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
 		},
 		"node_modules/@changesets/changelog-github": {
 			"version": "0.4.8",
@@ -171,35 +192,34 @@
 			}
 		},
 		"node_modules/@changesets/cli": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
-			"integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.1.tgz",
+			"integrity": "sha512-iJ91xlvRnnrJnELTp4eJJEOPjgpF3NOh4qeQehM6Ugiz9gJPRZ2t+TsXun6E3AMN4hScZKjqVXl0TX+C7AB3ZQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/apply-release-plan": "^6.1.4",
-				"@changesets/assemble-release-plan": "^5.2.4",
-				"@changesets/changelog-git": "^0.1.14",
-				"@changesets/config": "^2.3.1",
-				"@changesets/errors": "^0.1.4",
-				"@changesets/get-dependents-graph": "^1.3.6",
-				"@changesets/get-release-plan": "^3.0.17",
-				"@changesets/git": "^2.0.0",
-				"@changesets/logger": "^0.0.5",
-				"@changesets/pre": "^1.0.14",
-				"@changesets/read": "^0.5.9",
-				"@changesets/types": "^5.2.1",
-				"@changesets/write": "^0.2.3",
+				"@changesets/apply-release-plan": "^7.0.0",
+				"@changesets/assemble-release-plan": "^6.0.0",
+				"@changesets/changelog-git": "^0.2.0",
+				"@changesets/config": "^3.0.0",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/get-dependents-graph": "^2.0.0",
+				"@changesets/get-release-plan": "^4.0.0",
+				"@changesets/git": "^3.0.0",
+				"@changesets/logger": "^0.1.0",
+				"@changesets/pre": "^2.0.0",
+				"@changesets/read": "^0.6.0",
+				"@changesets/types": "^6.0.0",
+				"@changesets/write": "^0.3.0",
 				"@manypkg/get-packages": "^1.1.3",
-				"@types/is-ci": "^3.0.0",
 				"@types/semver": "^7.5.0",
 				"ansi-colors": "^4.1.3",
 				"chalk": "^2.1.0",
+				"ci-info": "^3.7.0",
 				"enquirer": "^2.3.0",
 				"external-editor": "^3.1.0",
 				"fs-extra": "^7.0.1",
 				"human-id": "^1.0.2",
-				"is-ci": "^3.0.1",
 				"meow": "^6.0.0",
 				"outdent": "^0.5.0",
 				"p-limit": "^2.2.0",
@@ -214,42 +234,60 @@
 				"changeset": "bin.js"
 			}
 		},
+		"node_modules/@changesets/cli/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/config": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
-			"integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.0.tgz",
+			"integrity": "sha512-o/rwLNnAo/+j9Yvw9mkBQOZySDYyOr/q+wptRLcAVGlU6djOeP9v1nlalbL9MFsobuBVQbZCTp+dIzdq+CLQUA==",
 			"dev": true,
 			"dependencies": {
-				"@changesets/errors": "^0.1.4",
-				"@changesets/get-dependents-graph": "^1.3.6",
-				"@changesets/logger": "^0.0.5",
-				"@changesets/types": "^5.2.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/get-dependents-graph": "^2.0.0",
+				"@changesets/logger": "^0.1.0",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"fs-extra": "^7.0.1",
 				"micromatch": "^4.0.2"
 			}
 		},
+		"node_modules/@changesets/config/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/errors": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.1.4.tgz",
-			"integrity": "sha512-HAcqPF7snsUJ/QzkWoKfRfXushHTu+K5KZLJWPb34s4eCZShIf8BFO3fwq6KU8+G7L5KdtN2BzQAXOSXEyiY9Q==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+			"integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
 			"dev": true,
 			"dependencies": {
 				"extendable-error": "^0.1.5"
 			}
 		},
 		"node_modules/@changesets/get-dependents-graph": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
-			"integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.0.0.tgz",
+			"integrity": "sha512-cafUXponivK4vBgZ3yLu944mTvam06XEn2IZGjjKc0antpenkYANXiiE6GExV/yKdsCnE8dXVZ25yGqLYZmScA==",
 			"dev": true,
 			"dependencies": {
-				"@changesets/types": "^5.2.1",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"chalk": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"semver": "^7.5.3"
 			}
+		},
+		"node_modules/@changesets/get-dependents-graph/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
 		},
 		"node_modules/@changesets/get-github-info": {
 			"version": "0.5.2",
@@ -262,88 +300,118 @@
 			}
 		},
 		"node_modules/@changesets/get-release-plan": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
-			"integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.0.tgz",
+			"integrity": "sha512-9L9xCUeD/Tb6L/oKmpm8nyzsOzhdNBBbt/ZNcjynbHC07WW4E1eX8NMGC5g5SbM5z/V+MOrYsJ4lRW41GCbg3w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/assemble-release-plan": "^5.2.4",
-				"@changesets/config": "^2.3.1",
-				"@changesets/pre": "^1.0.14",
-				"@changesets/read": "^0.5.9",
-				"@changesets/types": "^5.2.1",
+				"@changesets/assemble-release-plan": "^6.0.0",
+				"@changesets/config": "^3.0.0",
+				"@changesets/pre": "^2.0.0",
+				"@changesets/read": "^0.6.0",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3"
 			}
 		},
+		"node_modules/@changesets/get-release-plan/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/get-version-range-type": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz",
-			"integrity": "sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+			"integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
 			"dev": true
 		},
 		"node_modules/@changesets/git": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
-			"integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.0.tgz",
+			"integrity": "sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/errors": "^0.1.4",
-				"@changesets/types": "^5.2.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"is-subdir": "^1.1.1",
 				"micromatch": "^4.0.2",
 				"spawndamnit": "^2.0.0"
 			}
 		},
+		"node_modules/@changesets/git/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/logger": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.0.5.tgz",
-			"integrity": "sha512-gJyZHomu8nASHpaANzc6bkQMO9gU/ib20lqew1rVx753FOxffnCrJlGIeQVxNWCqM+o6OOleCo/ivL8UAO5iFw==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.0.tgz",
+			"integrity": "sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^2.1.0"
 			}
 		},
 		"node_modules/@changesets/parse": {
-			"version": "0.3.16",
-			"resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
-			"integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.0.tgz",
+			"integrity": "sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==",
 			"dev": true,
 			"dependencies": {
-				"@changesets/types": "^5.2.1",
+				"@changesets/types": "^6.0.0",
 				"js-yaml": "^3.13.1"
 			}
 		},
+		"node_modules/@changesets/parse/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/pre": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
-			"integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.0.tgz",
+			"integrity": "sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/errors": "^0.1.4",
-				"@changesets/types": "^5.2.1",
+				"@changesets/errors": "^0.2.0",
+				"@changesets/types": "^6.0.0",
 				"@manypkg/get-packages": "^1.1.3",
 				"fs-extra": "^7.0.1"
 			}
 		},
+		"node_modules/@changesets/pre/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
+		},
 		"node_modules/@changesets/read": {
-			"version": "0.5.9",
-			"resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
-			"integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.0.tgz",
+			"integrity": "sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/git": "^2.0.0",
-				"@changesets/logger": "^0.0.5",
-				"@changesets/parse": "^0.3.16",
-				"@changesets/types": "^5.2.1",
+				"@changesets/git": "^3.0.0",
+				"@changesets/logger": "^0.1.0",
+				"@changesets/parse": "^0.4.0",
+				"@changesets/types": "^6.0.0",
 				"chalk": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"p-filter": "^2.1.0"
 			}
+		},
+		"node_modules/@changesets/read/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
 		},
 		"node_modules/@changesets/types": {
 			"version": "5.2.1",
@@ -352,17 +420,23 @@
 			"dev": true
 		},
 		"node_modules/@changesets/write": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
-			"integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.0.tgz",
+			"integrity": "sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.1",
-				"@changesets/types": "^5.2.1",
+				"@changesets/types": "^6.0.0",
 				"fs-extra": "^7.0.1",
 				"human-id": "^1.0.2",
 				"prettier": "^2.7.1"
 			}
+		},
+		"node_modules/@changesets/write/node_modules/@changesets/types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+			"integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+			"dev": true
 		},
 		"node_modules/@changesets/write/node_modules/prettier": {
 			"version": "2.8.8",
@@ -380,15 +454,15 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20230814.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230814.0.tgz",
-			"integrity": "sha512-+jHiGjZg2UpULZSSHmHLqUG45TLg1s+uppSMlGvMn0u/xyFsRX9HX6b8Ydg/oHSp3jfSuPtX05GSvtgRAmrWTg==",
+			"version": "4.20231121.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231121.0.tgz",
+			"integrity": "sha512-+kWfpCkqiepwAKXyHoE0gnkPgkLhz0/9HOBIGhHRsUvUKvhUtm3mbqqoGRWgF1qcjzrDUBbrrOq4MYHfFtc2RA==",
 			"dev": true
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
-			"integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
+			"integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
 			"cpu": [
 				"arm"
 			],
@@ -402,9 +476,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
-			"integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
+			"integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
 			"cpu": [
 				"arm64"
 			],
@@ -418,9 +492,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
-			"integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
+			"integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
 			"cpu": [
 				"x64"
 			],
@@ -434,9 +508,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
-			"integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
+			"integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
 			"cpu": [
 				"arm64"
 			],
@@ -450,9 +524,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
-			"integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
+			"integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
 			"cpu": [
 				"x64"
 			],
@@ -466,9 +540,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
-			"integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
+			"integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
 			"cpu": [
 				"arm64"
 			],
@@ -482,9 +556,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
-			"integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
+			"integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
 			"cpu": [
 				"x64"
 			],
@@ -498,9 +572,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
-			"integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
+			"integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
 			"cpu": [
 				"arm"
 			],
@@ -514,9 +588,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
-			"integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
+			"integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -530,9 +604,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
-			"integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
+			"integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -546,9 +620,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
-			"integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
+			"integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -562,9 +636,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
-			"integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
+			"integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
 			"cpu": [
 				"mips64el"
 			],
@@ -578,9 +652,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
-			"integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
+			"integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -594,9 +668,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
-			"integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
+			"integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -610,9 +684,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
-			"integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
+			"integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
 			"cpu": [
 				"s390x"
 			],
@@ -626,9 +700,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
-			"integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
+			"integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
 			"cpu": [
 				"x64"
 			],
@@ -642,9 +716,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
-			"integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
+			"integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
 			"cpu": [
 				"x64"
 			],
@@ -658,9 +732,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
-			"integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
+			"integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
 			"cpu": [
 				"x64"
 			],
@@ -674,9 +748,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
-			"integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
+			"integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
 			"cpu": [
 				"x64"
 			],
@@ -690,9 +764,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
-			"integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
+			"integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -706,9 +780,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
-			"integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
+			"integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
 			"cpu": [
 				"ia32"
 			],
@@ -722,9 +796,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
-			"integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
+			"integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
 			"cpu": [
 				"x64"
 			],
@@ -737,10 +811,18 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+			"integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@jest/schemas": {
-			"version": "29.6.0",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-			"integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"dev": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
@@ -856,91 +938,239 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.7.0.tgz",
+			"integrity": "sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.7.0.tgz",
+			"integrity": "sha512-/EBw0cuJ/KVHiU2qyVYUhogXz7W2vXxBzeE9xtVIMC+RyitlY2vvaoysMUqASpkUtoNIHlnKTu/l7mXOPgnKOA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.7.0.tgz",
+			"integrity": "sha512-4VXG1bgvClJdbEYYjQ85RkOtwN8sqI3uCxH0HC5w9fKdqzRzgG39K7GAehATGS8jghA7zNoS5CjSKkDEqWmNZg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.7.0.tgz",
+			"integrity": "sha512-/ImhO+T/RWJ96hUbxiCn2yWI0/MeQZV/aeukQQfhxiSXuZJfyqtdHPUPrc84jxCfXTxbJLmg4q+GBETeb61aNw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.7.0.tgz",
+			"integrity": "sha512-zhye8POvTyUXlKbfPBVqoHy3t43gIgffY+7qBFqFxNqVtltQLtWeHNAbrMnXiLIfYmxcoL/feuLDote2tx+Qbg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.7.0.tgz",
+			"integrity": "sha512-RAdr3OJnUum6Vs83cQmKjxdTg31zJnLLTkjhcFt0auxM6jw00GD6IPFF42uasYPr/wGC6TRm7FsQiJyk0qIEfg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.7.0.tgz",
+			"integrity": "sha512-nhWwYsiJwZGq7SyR3afS3EekEOsEAlrNMpPC4ZDKn5ooYSEjDLe9W/xGvoIV8/F/+HNIY6jY8lIdXjjxfxopXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.7.0.tgz",
+			"integrity": "sha512-rlfy5RnQG1aop1BL/gjdH42M2geMUyVQqd52GJVirqYc787A/XVvl3kQ5NG/43KXgOgE9HXgCaEH05kzQ+hLoA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.7.0.tgz",
+			"integrity": "sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.7.0.tgz",
+			"integrity": "sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.7.0.tgz",
+			"integrity": "sha512-CPtgaQL1aaPc80m8SCVEoxFGHxKYIt3zQYC3AccL/SqqiWXblo3pgToHuBwR8eCP2Toa+X1WmTR/QKFMykws7g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.7.0.tgz",
+			"integrity": "sha512-pmioUlttNh9GXF5x2CzNa7Z8kmRTyhEzzAC+2WOOapjewMbl+3tGuAnxbwc5JyG8Jsz2+hf/QD/n5VjimOZ63g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.7.0.tgz",
+			"integrity": "sha512-SeZzC2QhhdBQUm3U0c8+c/P6UlRyBcLL2Xp5KX7z46WXZxzR8RJSIWL9wSUeBTgxog5LTPJuPj0WOT9lvrtP7Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
-		"node_modules/@types/chai": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
-			"integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
-			"dev": true
-		},
-		"node_modules/@types/chai-subset": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-			"integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
-			"dev": true,
-			"dependencies": {
-				"@types/chai": "*"
-			}
-		},
-		"node_modules/@types/is-ci": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.0.tgz",
-			"integrity": "sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^3.1.0"
-			}
-		},
 		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
-			"integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
-			"dev": true
+			"version": "20.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+			"integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
 			"dev": true
 		},
 		"node_modules/@vercel/ncc": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
-			"integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
+			"version": "0.38.1",
+			"resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+			"integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
 			"dev": true,
 			"bin": {
 				"ncc": "dist/ncc/cli.js"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.1.tgz",
-			"integrity": "sha512-q2CD8+XIsQ+tHwypnoCk8Mnv5e6afLFvinVGCq3/BOT4kQdVQmY6rRfyKkwcg635lbliLPqbunXZr+L1ssUWiQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.0.3.tgz",
+			"integrity": "sha512-J+JzGw/uvlWI3D3g8s0ewQo7C32nieF5VqEJpmIgAr8CAK36GvIQrV90lChEgQy79iwK3zyQx4UhfMeIF4572g==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "0.34.1",
-				"@vitest/utils": "0.34.1",
-				"chai": "^4.3.7"
+				"@vitest/spy": "1.0.3",
+				"@vitest/utils": "1.0.3",
+				"chai": "^4.3.10"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.1.tgz",
-			"integrity": "sha512-YfQMpYzDsYB7yqgmlxZ06NI4LurHWfrH7Wy3Pvf/z/vwUSgq1zLAb1lWcItCzQG+NVox+VvzlKQrYEXb47645g==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.0.3.tgz",
+			"integrity": "sha512-fCqShW4F8VJ78USVRoc5e1OD5jh1x1quZu4Mgp/lIhZS6PZPtI3wdCfRChWO9ZMJ2Ya7WI3sZTJZD69FR/AosA==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "0.34.1",
-				"p-limit": "^4.0.0",
+				"@vitest/utils": "1.0.3",
+				"p-limit": "^5.0.0",
 				"pathe": "^1.1.1"
 			},
 			"funding": {
@@ -948,64 +1178,64 @@
 			}
 		},
 		"node_modules/@vitest/runner/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+			"integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
 			"dev": true,
 			"dependencies": {
 				"yocto-queue": "^1.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.1.tgz",
-			"integrity": "sha512-0O9LfLU0114OqdF8lENlrLsnn024Tb1CsS9UwG0YMWY2oGTQfPtkW+B/7ieyv0X9R2Oijhi3caB1xgGgEgclSQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.0.3.tgz",
+			"integrity": "sha512-2EQwVEuHusEXr0SKuFiI1JVlysSrUceejtusr6vK254tusAz/g4//QrAiD1b7PMdcUKM8QmdgWvqCMaYDsWyNA==",
 			"dev": true,
 			"dependencies": {
-				"magic-string": "^0.30.1",
+				"magic-string": "^0.30.5",
 				"pathe": "^1.1.1",
-				"pretty-format": "^29.5.0"
+				"pretty-format": "^29.7.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.1.tgz",
-			"integrity": "sha512-UT4WcI3EAPUNO8n6y9QoEqynGGEPmmRxC+cLzneFFXpmacivjHZsNbiKD88KUScv5DCHVDgdBsLD7O7s1enFcQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.0.3.tgz",
+			"integrity": "sha512-aMd7kvqJuZ/h27Q5XqNOh9fRX7cQJ9fcaPX8q/lk5h2MkAqvq/HuqZ7n1xjm2SDOlDqg3xMaEqP/4inNlNG62A==",
 			"dev": true,
 			"dependencies": {
-				"tinyspy": "^2.1.1"
+				"tinyspy": "^2.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.1.tgz",
-			"integrity": "sha512-/ql9dsFi4iuEbiNcjNHQWXBum7aL8pyhxvfnD9gNtbjR9fUKAjxhj4AA3yfLXg6gJpMGGecvtF8Au2G9y3q47Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.0.3.tgz",
+			"integrity": "sha512-ddGKC6CVjxwjA+ourSlMD6Emc+PhIH6+d25ISGBOQjryXi2NtKpsBSOt1yDT793c2Tqij8g8BBxe87jam3B95w==",
 			"dev": true,
 			"dependencies": {
-				"diff-sequences": "^29.4.3",
-				"loupe": "^2.3.6",
-				"pretty-format": "^29.5.0"
+				"diff-sequences": "^29.6.3",
+				"loupe": "^2.3.7",
+				"pretty-format": "^29.7.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1015,9 +1245,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+			"integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -1085,14 +1315,14 @@
 			}
 		},
 		"node_modules/array.prototype.flat": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
@@ -1103,14 +1333,15 @@
 			}
 		},
 		"node_modules/arraybuffer.prototype.slice": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
-			"integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+			"integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
 			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"get-intrinsic": "^1.2.1",
 				"is-array-buffer": "^3.0.2",
 				"is-shared-array-buffer": "^1.0.2"
@@ -1195,13 +1426,14 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1234,18 +1466,18 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+			"version": "4.3.10",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+			"integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^4.1.2",
-				"get-func-name": "^2.0.0",
-				"loupe": "^2.3.1",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
-				"type-detect": "^4.0.5"
+				"type-detect": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=4"
@@ -1272,18 +1504,21 @@
 			"dev": true
 		},
 		"node_modules/check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
 			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-			"integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1474,12 +1709,27 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/define-properties": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
 			"dev": true,
 			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			},
@@ -1500,9 +1750,9 @@
 			}
 		},
 		"node_modules/diff-sequences": {
-			"version": "29.4.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-			"integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
 			"dev": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1558,26 +1808,26 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-			"integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+			"version": "1.22.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+			"integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
 			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
-				"arraybuffer.prototype.slice": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.2",
 				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.5",
 				"es-set-tostringtag": "^2.0.1",
 				"es-to-primitive": "^1.2.1",
-				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.2",
 				"get-symbol-description": "^1.0.0",
 				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
-				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0",
 				"internal-slot": "^1.0.5",
 				"is-array-buffer": "^3.0.2",
 				"is-callable": "^1.2.7",
@@ -1585,23 +1835,23 @@
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.10",
+				"is-typed-array": "^1.1.12",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.3",
+				"object-inspect": "^1.13.1",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.5.0",
-				"safe-array-concat": "^1.0.0",
+				"regexp.prototype.flags": "^1.5.1",
+				"safe-array-concat": "^1.0.1",
 				"safe-regex-test": "^1.0.0",
-				"string.prototype.trim": "^1.2.7",
-				"string.prototype.trimend": "^1.0.6",
-				"string.prototype.trimstart": "^1.0.6",
+				"string.prototype.trim": "^1.2.8",
+				"string.prototype.trimend": "^1.0.7",
+				"string.prototype.trimstart": "^1.0.7",
 				"typed-array-buffer": "^1.0.0",
 				"typed-array-byte-length": "^1.0.0",
 				"typed-array-byte-offset": "^1.0.0",
 				"typed-array-length": "^1.0.4",
 				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.10"
+				"which-typed-array": "^1.1.13"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -1611,26 +1861,26 @@
 			}
 		},
 		"node_modules/es-set-tostringtag": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+			"integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
-				"has-tostringtag": "^1.0.0"
+				"get-intrinsic": "^1.2.2",
+				"has-tostringtag": "^1.0.0",
+				"hasown": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			}
 		},
 		"node_modules/es-to-primitive": {
@@ -1651,9 +1901,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.18.17",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
-			"integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
+			"integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1663,28 +1913,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.18.17",
-				"@esbuild/android-arm64": "0.18.17",
-				"@esbuild/android-x64": "0.18.17",
-				"@esbuild/darwin-arm64": "0.18.17",
-				"@esbuild/darwin-x64": "0.18.17",
-				"@esbuild/freebsd-arm64": "0.18.17",
-				"@esbuild/freebsd-x64": "0.18.17",
-				"@esbuild/linux-arm": "0.18.17",
-				"@esbuild/linux-arm64": "0.18.17",
-				"@esbuild/linux-ia32": "0.18.17",
-				"@esbuild/linux-loong64": "0.18.17",
-				"@esbuild/linux-mips64el": "0.18.17",
-				"@esbuild/linux-ppc64": "0.18.17",
-				"@esbuild/linux-riscv64": "0.18.17",
-				"@esbuild/linux-s390x": "0.18.17",
-				"@esbuild/linux-x64": "0.18.17",
-				"@esbuild/netbsd-x64": "0.18.17",
-				"@esbuild/openbsd-x64": "0.18.17",
-				"@esbuild/sunos-x64": "0.18.17",
-				"@esbuild/win32-arm64": "0.18.17",
-				"@esbuild/win32-ia32": "0.18.17",
-				"@esbuild/win32-x64": "0.18.17"
+				"@esbuild/android-arm": "0.19.8",
+				"@esbuild/android-arm64": "0.19.8",
+				"@esbuild/android-x64": "0.19.8",
+				"@esbuild/darwin-arm64": "0.19.8",
+				"@esbuild/darwin-x64": "0.19.8",
+				"@esbuild/freebsd-arm64": "0.19.8",
+				"@esbuild/freebsd-x64": "0.19.8",
+				"@esbuild/linux-arm": "0.19.8",
+				"@esbuild/linux-arm64": "0.19.8",
+				"@esbuild/linux-ia32": "0.19.8",
+				"@esbuild/linux-loong64": "0.19.8",
+				"@esbuild/linux-mips64el": "0.19.8",
+				"@esbuild/linux-ppc64": "0.19.8",
+				"@esbuild/linux-riscv64": "0.19.8",
+				"@esbuild/linux-s390x": "0.19.8",
+				"@esbuild/linux-x64": "0.19.8",
+				"@esbuild/netbsd-x64": "0.19.8",
+				"@esbuild/openbsd-x64": "0.19.8",
+				"@esbuild/sunos-x64": "0.19.8",
+				"@esbuild/win32-arm64": "0.19.8",
+				"@esbuild/win32-ia32": "0.19.8",
+				"@esbuild/win32-x64": "0.19.8"
 			}
 		},
 		"node_modules/escalade": {
@@ -1718,6 +1968,100 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/execa/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/execa/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/execa/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/execa/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/execa/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/extendable-error": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
@@ -1739,9 +2083,9 @@
 			}
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1822,9 +2166,9 @@
 			}
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
@@ -1836,21 +2180,24 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/function.prototype.name": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0",
-				"functions-have-names": "^1.2.2"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -1878,27 +2225,39 @@
 			}
 		},
 		"node_modules/get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
+				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3"
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-symbol-description": {
@@ -1997,18 +2356,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -2028,12 +2375,12 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.1"
+				"get-intrinsic": "^1.2.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2078,6 +2425,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/hosted-git-info": {
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -2089,6 +2448,15 @@
 			"resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
 			"integrity": "sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==",
 			"dev": true
+		},
+		"node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.17.0"
+			}
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
@@ -2103,9 +2471,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -2121,13 +2489,13 @@
 			}
 		},
 		"node_modules/internal-slot": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+			"integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.2.0",
-				"has": "^1.0.3",
+				"get-intrinsic": "^1.2.2",
+				"hasown": "^2.0.0",
 				"side-channel": "^1.0.4"
 			},
 			"engines": {
@@ -2194,25 +2562,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
-			}
-		},
 		"node_modules/is-core-module": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2334,6 +2690,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-string": {
@@ -2506,10 +2874,14 @@
 			}
 		},
 		"node_modules/local-pkg": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
-			"integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+			"integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
 			"dev": true,
+			"dependencies": {
+				"mlly": "^1.4.2",
+				"pkg-types": "^1.0.3"
+			},
 			"engines": {
 				"node": ">=14"
 			},
@@ -2536,12 +2908,12 @@
 			"dev": true
 		},
 		"node_modules/loupe": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-			"integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
 			"dev": true,
 			"dependencies": {
-				"get-func-name": "^2.0.0"
+				"get-func-name": "^2.0.1"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -2557,9 +2929,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-			"integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2605,6 +2977,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2625,6 +3003,18 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/min-indent": {
@@ -2651,24 +3041,24 @@
 			}
 		},
 		"node_modules/mixme": {
-			"version": "0.5.9",
-			"resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.9.tgz",
-			"integrity": "sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==",
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.10.tgz",
+			"integrity": "sha512-5H76ANWinB1H3twpJ6JY8uvAtpmFvHNArpilJAjXRKXSDDLPIMoZArw5SH0q9z+lLs8IrMw7Q2VWpWimFKFT1Q==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
-			"integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
+			"integrity": "sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.9.0",
+				"acorn": "^8.10.0",
 				"pathe": "^1.1.1",
 				"pkg-types": "^1.0.3",
-				"ufo": "^1.1.2"
+				"ufo": "^1.3.0"
 			}
 		},
 		"node_modules/ms": {
@@ -2678,9 +3068,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"dev": true,
 			"funding": [
 				{
@@ -2696,9 +3086,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
 			"dev": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
@@ -2736,10 +3126,25 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/npm-run-path": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/object-inspect": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2755,13 +3160,13 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			},
@@ -2770,6 +3175,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/os-tmpdir": {
@@ -2871,6 +3291,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2952,9 +3384,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"version": "8.4.32",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2971,7 +3403,7 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.6",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -2980,9 +3412,9 @@
 			}
 		},
 		"node_modules/preferred-pm": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.0.3.tgz",
-			"integrity": "sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.2.tgz",
+			"integrity": "sha512-nk7dKrcW8hfCZ4H6klWcdRknBOXWzNQByJ0oJyX97BOupsYD+FzLS4hflgEu/uPUEHZCuRfMxzCBsuWd7OzT8Q==",
 			"dev": true,
 			"dependencies": {
 				"find-up": "^5.0.0",
@@ -3068,9 +3500,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-			"integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+			"integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -3083,12 +3515,12 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "29.6.2",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
-			"integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/schemas": "^29.6.0",
+				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
 				"react-is": "^18.0.0"
 			},
@@ -3228,20 +3660,20 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
 			"dev": true
 		},
 		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-			"integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+			"integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
-				"functions-have-names": "^1.2.3"
+				"set-function-name": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3266,12 +3698,12 @@
 			"dev": true
 		},
 		"node_modules/resolve": {
-			"version": "1.22.2",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-			"integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.11.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -3302,18 +3734,31 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
-			"integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.7.0.tgz",
+			"integrity": "sha512-7Kw0dUP4BWH78zaZCqF1rPyQ8D5DSU6URG45v1dqS/faNsx9WXyess00uTOZxKr7oR/4TOjO1CPudT8L1UsEgw==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=14.18.0",
+				"node": ">=18.0.0",
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.7.0",
+				"@rollup/rollup-android-arm64": "4.7.0",
+				"@rollup/rollup-darwin-arm64": "4.7.0",
+				"@rollup/rollup-darwin-x64": "4.7.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.7.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.7.0",
+				"@rollup/rollup-linux-arm64-musl": "4.7.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.7.0",
+				"@rollup/rollup-linux-x64-gnu": "4.7.0",
+				"@rollup/rollup-linux-x64-musl": "4.7.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.7.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.7.0",
+				"@rollup/rollup-win32-x64-msvc": "4.7.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -3341,13 +3786,13 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
-			"integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+			"integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.0",
+				"get-intrinsic": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"isarray": "^2.0.5"
 			},
@@ -3398,6 +3843,35 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"dev": true
+		},
+		"node_modules/set-function-length": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+			"integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/shebang-command": {
 			"version": "1.2.0",
@@ -3607,9 +4081,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.13",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-			"integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+			"integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
 			"dev": true
 		},
 		"node_modules/sprintf-js": {
@@ -3625,9 +4099,9 @@
 			"dev": true
 		},
 		"node_modules/std-env": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.3.tgz",
-			"integrity": "sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
+			"integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==",
 			"dev": true
 		},
 		"node_modules/stream-transform": {
@@ -3654,14 +4128,14 @@
 			}
 		},
 		"node_modules/string.prototype.trim": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-			"integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+			"integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3671,28 +4145,28 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+			"integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+			"integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3719,6 +4193,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -3732,9 +4218,9 @@
 			}
 		},
 		"node_modules/strip-literal": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.2.0.tgz",
-			"integrity": "sha512-tbehiynUAVoOhVKgpGG/xSIEPq3mDH3MmZ3957hiCBt2SnxkgOfXnZ8X2Kjfzb2L/6Vsv8Lnh8WT9qV5zQ0tMA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+			"integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.10.0"
@@ -3780,24 +4266,24 @@
 			}
 		},
 		"node_modules/tinybench": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
-			"integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
+			"integrity": "sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==",
 			"dev": true
 		},
 		"node_modules/tinypool": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
-			"integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.1.tgz",
+			"integrity": "sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-			"integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+			"integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -3843,9 +4329,9 @@
 			}
 		},
 		"node_modules/tty-table": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.1.tgz",
-			"integrity": "sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.2.3.tgz",
+			"integrity": "sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
@@ -4028,9 +4514,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -4041,9 +4527,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.2.0.tgz",
-			"integrity": "sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+			"integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
 			"dev": true
 		},
 		"node_modules/unbox-primitive": {
@@ -4060,6 +4546,23 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/undici": {
+			"version": "5.28.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+			"integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"node_modules/universalify": {
 			"version": "0.1.2",
@@ -4089,29 +4592,29 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.4.9",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-			"integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.0.7.tgz",
+			"integrity": "sha512-B4T4rJCDPihrQo2B+h1MbeGL/k/GMAHzhQ8S0LjQ142s6/+l3hHTT095ORvsshj4QCkoWu3Xtmob5mazvakaOw==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.18.10",
-				"postcss": "^8.4.27",
-				"rollup": "^3.27.1"
+				"esbuild": "^0.19.3",
+				"postcss": "^8.4.32",
+				"rollup": "^4.2.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
 			},
 			"optionalDependencies": {
-				"fsevents": "~2.3.2"
+				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": ">= 14",
+				"@types/node": "^18.0.0 || >=20.0.0",
 				"less": "*",
 				"lightningcss": "^1.21.0",
 				"sass": "*",
@@ -4144,80 +4647,77 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.1.tgz",
-			"integrity": "sha512-odAZAL9xFMuAg8aWd7nSPT+hU8u2r9gU3LRm9QKjxBEF2rRdWpMuqkrkjvyVQEdNFiBctqr2Gg4uJYizm5Le6w==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.0.3.tgz",
+			"integrity": "sha512-7AH08/UgJQm4gWFyXB6xQ1AvI+iMioM2duPmptytxEbkHamVrOhoha4REt9xvOgyiw91G9OykRlixN4zIsQOQg==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
 				"debug": "^4.3.4",
-				"mlly": "^1.4.0",
 				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
-				"vite": "^3.0.0 || ^4.0.0"
+				"vite": "^5.0.0"
 			},
 			"bin": {
 				"vite-node": "vite-node.mjs"
 			},
 			"engines": {
-				"node": ">=v14.18.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/vitest": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.1.tgz",
-			"integrity": "sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-1.0.3.tgz",
+			"integrity": "sha512-zbMmAdRjTki6mYXEjCXMVH8Vb0FX0rAfCSTrbbn3Dqd8Zz6FzImBavkKYsOF+iXd4+k5RoOqi6RyTSoroRS0mw==",
 			"dev": true,
 			"dependencies": {
-				"@types/chai": "^4.3.5",
-				"@types/chai-subset": "^1.3.3",
-				"@types/node": "*",
-				"@vitest/expect": "0.34.1",
-				"@vitest/runner": "0.34.1",
-				"@vitest/snapshot": "0.34.1",
-				"@vitest/spy": "0.34.1",
-				"@vitest/utils": "0.34.1",
-				"acorn": "^8.9.0",
-				"acorn-walk": "^8.2.0",
+				"@vitest/expect": "1.0.3",
+				"@vitest/runner": "1.0.3",
+				"@vitest/snapshot": "1.0.3",
+				"@vitest/spy": "1.0.3",
+				"@vitest/utils": "1.0.3",
+				"acorn-walk": "^8.3.0",
 				"cac": "^6.7.14",
-				"chai": "^4.3.7",
+				"chai": "^4.3.10",
 				"debug": "^4.3.4",
-				"local-pkg": "^0.4.3",
-				"magic-string": "^0.30.1",
+				"execa": "^8.0.1",
+				"local-pkg": "^0.5.0",
+				"magic-string": "^0.30.5",
 				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
-				"std-env": "^3.3.3",
-				"strip-literal": "^1.0.1",
-				"tinybench": "^2.5.0",
-				"tinypool": "^0.7.0",
-				"vite": "^3.0.0 || ^4.0.0",
-				"vite-node": "0.34.1",
+				"std-env": "^3.5.0",
+				"strip-literal": "^1.3.0",
+				"tinybench": "^2.5.1",
+				"tinypool": "^0.8.1",
+				"vite": "^5.0.0",
+				"vite-node": "1.0.3",
 				"why-is-node-running": "^2.2.2"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": ">=v14.18.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
-				"@vitest/browser": "*",
-				"@vitest/ui": "*",
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"@vitest/browser": "^1.0.0",
+				"@vitest/ui": "^1.0.0",
 				"happy-dom": "*",
-				"jsdom": "*",
-				"playwright": "*",
-				"safaridriver": "*",
-				"webdriverio": "*"
+				"jsdom": "*"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/node": {
 					"optional": true
 				},
 				"@vitest/browser": {
@@ -4230,15 +4730,6 @@
 					"optional": true
 				},
 				"jsdom": {
-					"optional": true
-				},
-				"playwright": {
-					"optional": true
-				},
-				"safaridriver": {
-					"optional": true
-				},
-				"webdriverio": {
 					"optional": true
 				}
 			}
@@ -4316,13 +4807,13 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-			"integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
 			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.4",
 				"for-each": "^0.3.3",
 				"gopd": "^1.0.1",
 				"has-tostringtag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
 		"check": "prettier --check ."
 	},
 	"dependencies": {
-		"@actions/core": "^1.10.0",
+		"@actions/core": "^1.10.1",
 		"@actions/exec": "^1.1.1"
 	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.4.8",
 		"@changesets/cli": "^2.26.2",
-		"@cloudflare/workers-types": "^4.20230814.0",
-		"@types/node": "^20.5.0",
-		"@vercel/ncc": "^0.36.1",
-		"prettier": "^3.0.1",
-		"typescript": "^5.1.6",
-		"vitest": "^0.34.1"
+		"@cloudflare/workers-types": "^4.20231121.0",
+		"@types/node": "^20.10.4",
+		"@vercel/ncc": "^0.38.1",
+		"prettier": "^3.1.0",
+		"semver": "^7.5.4",
+		"typescript": "^5.3.3",
+		"vitest": "^1.0.3"
 	}
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -30,3 +30,26 @@ describe("checkWorkingDirectory", () => {
 		);
 	});
 });
+
+describe("semverCompare", () => {
+	test.each([
+		["1.2.3", "1.2.3", false],
+		["1.2.2", "1.2.3", true],
+		["2.0.0", "3.0.0", true],
+		["3.1.0", "3.1.1", true],
+		["3.1.0", "3.5.0", true],
+		["3.1.0", "3.10.0", true],
+		["3.1.0", "3.15.0", true],
+		["3.10.0", "3.1.0", false],
+		["3.20.0", "3.2.0", false],
+		["3.1.0", "latest", true],
+		["4.0.0", "latest", true],
+	])(
+		"should semver compare %s vs %s correctly, expecting %s",
+		(version1, version2, expected) => {
+			const isVersion1LessThanVersion2 = semverCompare(version1, version2);
+
+			expect(isVersion1LessThanVersion2).toBe(expected);
+		},
+	);
+});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -26,7 +26,7 @@ describe("checkWorkingDirectory", () => {
 		expect(() =>
 			checkWorkingDirectory("/does/not/exist"),
 		).toThrowErrorMatchingInlineSnapshot(
-			'"Directory /does/not/exist does not exist."',
+			`[Error: Directory /does/not/exist does not exist.]`,
 		);
 	});
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import * as path from "node:path";
+import semverGt from "semver/functions/gt";
 
 /**
  * A helper function to compare two semver versions. If the second arg is greater than the first arg, it returns true.
@@ -7,18 +8,7 @@ import * as path from "node:path";
 export function semverCompare(version1: string, version2: string) {
 	if (version2 === "latest") return true;
 
-	const version1Parts = version1.split(".");
-	const version2Parts = version2.split(".");
-
-	for (const version1Part of version1Parts) {
-		const version2Part = version2Parts.shift();
-
-		if (version1Part !== version2Part && version2Part) {
-			return version1Part < version2Part ? true : false;
-		}
-	}
-
-	return false;
+	return semverGt(version2, version1);
 }
 
 export function checkWorkingDirectory(workingDirectory = ".") {


### PR DESCRIPTION
fixes #215 
closes #214 

This also bumps a few dependencies, to remove some `npm audit` warnings. The output bundle increases from `964kB` to `983kB`, but I feel the 19kB increase is worth the reliable semver comparison.