### PR TITLE
docs: remove warning about packageManager and pnpm default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          packageManager: pnpm # you can omit this if you use npm
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
@@ -52,10 +51,6 @@ jobs:
 ```
 
 ## Configuration
-
-### packageManager
-
-⚠️ you must specify package manager. If not specified GH action assumes you are using npm and other managers might be failing. For example pnpm will fail with: `Cannot read properties of null (reading 'matches')`
 
 If you need to install a specific version of Wrangler to use for deployment, you can also pass the input `wranglerVersion` to install a specific version of Wrangler from NPM. This should be a [SemVer](https://semver.org/)-style version number, such as `2.20.0`:
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ https://<your_pages_site>.pages.dev
 
 ### Using a different package manager
 
-By default, this action will detect which package manager to use, based on the presence of a `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb` file. 
+By default, this action will detect which package manager to use, based on the presence of a `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb` file.
 
 If you need to use a specific package manager for your application, you can set the `packageManager` input to `npm`, `yarn`, `pnpm`, or `bun`. You don't need to set this option unless you want to override the default behavior.
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,23 @@ The resulting output will look something like this:
 https://<your_pages_site>.pages.dev
 ```
 
+### Using a different package manager
+
+By default, this action will detect which package manager to use, based on the presence of a `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb` file. 
+
+If you need to use a specific package manager for your application, you can set the `packageManager` input to `npm`, `yarn`, `pnpm`, or `bun`. You don't need to set this option unless you want to override the default behavior.
+
+
+```yaml
+jobs:
+  deploy:
+    steps:
+      uses: cloudflare/wrangler-action@v3
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        packageManager: pnpm
+```
+
 ## Troubleshooting
 
 ### "I just started using Workers/Wrangler and I don't know what this is!"

--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ By default, this action will detect which package manager to use, based on the p
 
 If you need to use a specific package manager for your application, you can set the `packageManager` input to `npm`, `yarn`, `pnpm`, or `bun`. You don't need to set this option unless you want to override the default behavior.
 
-
 ```yaml
 jobs:
   deploy:


### PR DESCRIPTION
This effectively reverts https://github.com/cloudflare/wrangler-action/pull/242.

---


This is inferred by https://github.com/cloudflare/wrangler-action/pull/190 and then fixed in https://github.com/cloudflare/wrangler-action/pull/193, and I'm not really sure the "default" copy/pasted config should use `pnpm` - that's definitely not the standard.

> The package manager you'd like to use to install and run wrangler. If not specified, the preferred package manager will be inferred based on the presence of a lockfile or fallback to using npm if no lockfile is found. Valid values are npm | pnpm | yarn | bun.

You do not need to specify `packageManager` as the docs now suggests, as long as you're running an up to date version.

If there is a bug in the package manager detection, I'd suggest that should be reported and addressed separately. 