### PR TITLE
Add `versions upload` instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,25 @@ jobs:
 
 For more advanced usage or to programmatically trigger the workflow from scripts, refer to [the GitHub documentation](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event) for making API calls.
 
+### Upload a Worker Version
+
+To create a new Version of your Worker that is not deployed immediately, use the `wrangler versions upload --experimental-versions` command. Worker Versions created in this way can then be deployed all at once or gradually deployed using the `wranger versions deploy --experimental-versions` command or via the Cloudflare dashboard under the Deployments tab. For now, the `--experimental-versions` flag is required to use this feature.
+
+```yaml
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload Worker Version
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: versions upload --experimental-versions
+```
+
 ## Advanced Usage
 
 ### Using Wrangler Command Output in Subsequent Steps

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For more advanced usage or to programmatically trigger the workflow from scripts
 
 ### Upload a Worker Version
 
-To create a new Version of your Worker that is not deployed immediately, use the `wrangler versions upload --experimental-versions` command. Worker Versions created in this way can then be deployed all at once or gradually deployed using the `wranger versions deploy --experimental-versions` command or via the Cloudflare dashboard under the Deployments tab. For now, the `--experimental-versions` flag is required to use this feature.
+To create a new Version of your Worker that is not deployed immediately, use the `wrangler versions upload --experimental-versions` command. Worker Versions created in this way can then be deployed all at once or gradually deployed using the `wranger versions deploy --experimental-versions` command or via the Cloudflare dashboard under the Deployments tab. For now, the `--experimental-versions` flag and wrangler v3.40.0 or above is required to use this feature.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For more advanced usage or to programmatically trigger the workflow from scripts
 
 ### Upload a Worker Version
 
-To create a new Version of your Worker that is not deployed immediately, use the `wrangler versions upload --experimental-versions` command. Worker Versions created in this way can then be deployed all at once or gradually deployed using the `wranger versions deploy --experimental-versions` command or via the Cloudflare dashboard under the Deployments tab. For now, the `--experimental-versions` flag and wrangler v3.40.0 or above is required to use this feature.
+To create a new version of your Worker that is not deployed immediately, use the `wrangler versions upload --experimental-versions` command. Worker versions created in this way can then be deployed all at once at a later time or gradually deployed using the `wranger versions deploy --experimental-versions` command or via the Cloudflare dashboard under the Deployments tab. For now, the `--experimental-versions` flag and wrangler v3.40.0 or above is required to use this feature.
 
 ```yaml
 jobs:


### PR DESCRIPTION
This PR adds instructions to README for how to upload a Worker Version using this Github Action.

There are no code changes so a changeset is not required.