### PR TITLE
Stop racing secret uploads

### DIFF
--- a/.changeset/funny-boats-care.md
+++ b/.changeset/funny-boats-care.md
@@ -1,0 +1,13 @@
+---
+"wrangler-action": minor
+---
+
+Stop racing secret uploads
+
+For up to date versions of wrangler, secrets are uploaded via the 'secret:bulk' command, which batches updates in a single API call.
+
+For versions of wrangler without that capability, the action falls back to the single 'secret put' command for each secret. It races all these with a Promise.all()
+
+Unfortunately, the single secret API cannot handle concurrency - at best, these calls have to wait on one another, holding requests open all the while. Often it times out and errors.
+
+This fixes the legacy secret upload errors by making these calls serially instead of concurrently.

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,24 +152,22 @@ function getEnvVar(envVar: string) {
 	return value;
 }
 
-function legacyUploadSecrets(
+async function legacyUploadSecrets(
 	secrets: string[],
 	environment?: string,
 	workingDirectory?: string,
 ) {
-	return Promise.all(
-		secrets.map((secret) => {
-			const args = ["wrangler", "secret", "put", secret];
-			if (environment) {
-				args.push("--env", environment);
-			}
-			return exec(packageManager.exec, args, {
-				cwd: workingDirectory,
-				silent: config["QUIET_MODE"],
-				input: Buffer.from(getSecret(secret)),
-			});
-		}),
-	);
+	for (const secret of secrets) {
+		const args = ["wrangler", "secret", "put", secret];
+		if (environment) {
+			args.push("--env", environment);
+		}
+		await exec(packageManager.exec, args, {
+			cwd: workingDirectory,
+			silent: config["QUIET_MODE"],
+			input: Buffer.from(getSecret(secret)),
+		});
+	}
 }
 
 async function uploadSecrets() {


### PR DESCRIPTION
For up to date versions of wrangler, secrets are uploaded via the 'secret:bulk' command, which batches updates in a single API call.

For versions of wrangler without that capability, the action falls back to the single 'secret put' command for each secret. It races all these with a Promise.all()

Unfortunately, the single secret API cannot handle concurrency - at best, these calls have to wait on one another, holding requests open all the while. Often it times out and errors.

This fixes the legacy secret upload errors by making these calls serially instead of concurrently.