### PR TITLE
When checking for existing wrangler install, match wrangler version even if multiline output

### DIFF
--- a/.changeset/gentle-cobras-move.md
+++ b/.changeset/gentle-cobras-move.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+fix: Detect existing wrangler install even when wrangler version output is multiline

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ async function installWrangler() {
 		// `3.48.0`
 		const versionMatch =
 			stdout.match(/wrangler (\d+\.\d+\.\d+)/) ??
-			stdout.match(/^(\d+\.\d+\.\d+)/);
+			stdout.match(/^(\d+\.\d+\.\d+)/m);
 		if (versionMatch) {
 			installedVersion = versionMatch[1];
 		}


### PR DESCRIPTION
implements #277

i don’t know how to test or verify this, but in case it’s helpful, here’s my proposed solution (assuming my hypothesis from #277 is correct).

i think this will also fix the issue documented here: https://github.com/cloudflare/wrangler-action/issues/199#issuecomment-2188863592