### PR TITLE
Add deployment-alias-url for pages deployments with Wrangler 3.78.0+

### DIFF
--- a/.changeset/little-cougars-shout.md
+++ b/.changeset/little-cougars-shout.md
@@ -1,0 +1,6 @@
+---
+"wrangler-action": minor
+---
+
+Adds `deployment-alias-url` output for Pages deployment aliases (since Wrangler v3.78.0): https://github.com/cloudflare/workers-sdk/pull/6643
+

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Now when you run your workflow, you will see the full output of the Wrangler com
 
 > Note: the `command-stderr` output variable is also available if you need to parse the standard error output of the Wrangler command.
 
-### Using the `deployment-url` Output Variable
+### Using the `deployment-url` and `deployment-alias-url` Output Variables
 
 If you are executing a Wrangler command that results in either a Workers or Pages deployment, you can utilize the `deployment-url` output variable to get the URL of the deployment. For example, if you want to print the deployment URL after deploying your application, you can do the following:
 
@@ -285,6 +285,23 @@ The resulting output will look something like this:
 
 ```text
 https://<your_pages_site>.pages.dev
+```
+
+Pages deployments will also provide their alias URL (since Wrangler v3.78.0). You can use the `deployment-alias-url` output variable to get the URL of the deployment alias. This is useful for, for example, branch aliases for preview deployments.
+
+If the sample action above was used to deploy a branch other than main, you could use the following to get the branch URL:
+
+```yaml
+- name: print deployment-alias-url
+  env:
+    DEPLOYMENT_ALIAS_URL: ${{ steps.deploy.outputs.deployment-alias-url }}
+  run: echo $DEPLOYMENT_ALIAS_URL
+```
+
+Resulting in:
+
+```text
+https://new-feature.<your_pages_site>.pages.dev
 ```
 
 ### Using a different package manager

--- a/action.yml
+++ b/action.yml
@@ -51,3 +51,5 @@ outputs:
     description: "The error output of the Wrangler command (comes from stderr)"
   deployment-url:
     description: "If the command was a Workers or Pages deployment, this will be the URL of the deployment"
+  deployment-alias-url:
+    description: "If the command was a Workers or Pages deployment, this can be the URL of the deployment alias (if it exists) - needs wrangler >= 3.78.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,6 +347,15 @@ async function wranglerCommands() {
 					deploymentUrl = deploymentUrlMatch[0].trim();
 					setOutput("deployment-url", deploymentUrl);
 				}
+
+				// And also try to extract the alias URL (since wrangler@3.78.0)
+				const aliasUrlMatch = stdOut.match(
+					/alias URL: (https?:\/\/[a-zA-Z0-9-./]+)/,
+				);
+				if (aliasUrlMatch && aliasUrlMatch.length == 2 && aliasUrlMatch[1]) {
+					const aliasUrl = aliasUrlMatch[1].trim();
+					setOutput("deployment-alias-url", aliasUrl);
+				}
 			}
 		}
 	} finally {


### PR DESCRIPTION
Since the lovely PR https://github.com/cloudflare/workers-sdk/pull/6643 that landed in Wrangler 3.78.0 it's now possible to get the deployment alias from the `pages deploy` output too.

This PR exposes that in a backwards compatible way. When there is no alias (or on older Wrangler versions) it'll just not be set.

I tested this in our local repo on commit https://github.com/Ambroos/wrangler-action/commit/6dcec6789d82c53bb800db578877e56cc81c2c45 (which contains dist) but is otherwise identical to this PR, and things seem very functional. Output below:


```
Run Ambroos/wrangler-action@6dcec6789d82c53bb800db578877e56cc8[1](snip#step:13:1)c2c45
  with:
    wranglerVersion: 3.78.5
    apiToken: ***
    accountId: ***
    workingDirectory: packages/snip
    command: pages deploy "snip" --project-name=snip --branch="ci/use-real-cf-preview-branch-url" --commit-message="ci: use real CF preview branch url" --commit-hash="snip"
    quiet: false
  env:
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
🔍 Checking for existing Wrangler installation
  /opt/hostedtoolcache/node/20.17.0/x64/bin/npx --no-install wrangler --version 3.78.5
  ✅ Using Wrangler 3.78.5

🚀 Running Wrangler Commands
  /opt/hostedtoolcache/node/20.17.0/x6[4](snip#step:13:4)/bin/npx wrangler pages deploy style-guide/build --project-name=ui --branch=ci/use-real-cf-preview-branch-url --commit-message=ci: use real CF preview branch url --commit-hash=snip
  Uploading... (5/5)
  ✨ Success! Uploaded 0 files (5 already uploaded)
  🌎 Deploying...
  ✨ Deployment complete! Take a peek over at https://abcdef.snip.pages.dev
  ✨ Deployment alias URL: https://ci-use-real-cf-preview-branc.snip.pages.dev
🏁 Wrangler Action completed


Run echo "### Deployed preview to Cloudflare Pages" >> $GITHUB_STEP_SUMMARY
  echo "### Deployed preview to Cloudflare Pages" >> $GITHUB_STEP_SUMMARY
  echo "🌩️ Preview URL: https://abcdef.snip.pages.dev" >> $GITHUB_STEP_SUMMARY
  echo "🌳 Branch URL: https://ci-use-real-cf-preview-branc.snip.pages.dev" >> $GITHUB_STEP_SUMMARY
```