### PR TITLE
WO-202: update wrangler version so the github action works out of the box with Workers Observability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { exec, execShell } from "./exec";
 import { checkWorkingDirectory, semverCompare } from "./utils";
 import { getPackageManager } from "./packageManagers";
 
-const DEFAULT_WRANGLER_VERSION = "3.13.2";
+const DEFAULT_WRANGLER_VERSION = "3.78.10";
 
 /**
  * A configuration object that contains all the inputs & immutable state for the action.


### PR DESCRIPTION
Hi folks, several users using this action have reported observability enabled=true not working in there wrangler configs

Tracked the issue down to the default version here being out of date.

I would be grateful if we could bump this up to the latest