### PR TITLE
Add parity with pages-action for Pages deploy outputs

### DIFF
--- a/.changeset/fast-experts-shop.md
+++ b/.changeset/fast-experts-shop.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Support id, environment, url, and alias outputs for Pages deploys.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
 	"name": "wrangler-action",
-	"version": "3.7.0",
+	"version": "3.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.7.0",
+			"version": "3.9.0",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.10.1",
-				"@actions/exec": "^1.1.1"
+				"@actions/exec": "^1.1.1",
+				"zod": "^3.23.8"
 			},
 			"devDependencies": {
 				"@changesets/changelog-github": "^0.4.8",
@@ -18,6 +19,7 @@
 				"@cloudflare/workers-types": "^4.20231121.0",
 				"@types/node": "^20.10.4",
 				"@vercel/ncc": "^0.38.1",
+				"mock-fs": "^5.4.0",
 				"prettier": "^3.1.0",
 				"semver": "^7.5.4",
 				"typescript": "^5.3.3",
@@ -3110,6 +3112,16 @@
 				"ufo": "^1.3.0"
 			}
 		},
+		"node_modules/mock-fs": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.4.0.tgz",
+			"integrity": "sha512-3ROPnEMgBOkusBMYQUW2rnT3wZwsgfOKzJDLvx/TZ7FL1WmWvwSwn3j4aDR5fLDGtgcc1WF0Z1y0di7c9L4FKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5010,6 +5022,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.23.8",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	},
 	"dependencies": {
 		"@actions/core": "^1.10.1",
-		"@actions/exec": "^1.1.1"
+		"@actions/exec": "^1.1.1",
+		"zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.4.8",
@@ -39,6 +40,7 @@
 		"@types/node": "^20.10.4",
 		"@vercel/ncc": "^0.38.1",
 		"prettier": "^3.1.0",
+		"mock-fs": "^5.4.0",
 		"semver": "^7.5.4",
 		"typescript": "^5.3.3",
 		"vitest": "^1.0.3"

--- a/src/wranglerArtifactManager.test.ts
+++ b/src/wranglerArtifactManager.test.ts
@@ -1,0 +1,89 @@
+import mock from "mock-fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getDetailedPagesDeployOutput,
+	getWranglerArtifacts,
+} from "./wranglerArtifactManager";
+
+afterEach(async () => {
+	mock.restore();
+});
+describe("wranglerArtifactsManager", () => {
+	describe("getWranglerArtifacts()", async () => {
+		it("Returns only wrangler output files from a given directory", async () => {
+			mock({
+				testOutputDir: {
+					"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+                    {"version": 1, "type":"wrangler-session", "wrangler_version":"3.81.0", "command_line_args":["what's up"], "log_file_path": "/here"}
+                    {"version": 1, "type":"pages-deploy-detailed", "environment":"production", "alias":"test.com", "deployment_id": "123", "url":"url.com"}`,
+					"not-wrangler-output.json": "test",
+				},
+			});
+
+			const artifacts = await getWranglerArtifacts("./testOutputDir");
+
+			expect(artifacts).toEqual([
+				"./testOutputDir/wrangler-output-2024-10-17_18-48-40_463-2e6e83.json",
+			]);
+			//mock.restore();
+		});
+		it("Returns an empty list when the output directory doesn't exist", async () => {
+			mock({
+				notTheDirWeWant: {},
+			});
+
+			const artifacts = await getWranglerArtifacts("./testOutputDir");
+			expect(artifacts).toEqual([]);
+			//mock.restore();
+		});
+	});
+
+	describe("getDetailedPagesDeployOutput()", async () => {
+		it("Returns only detailed pages deploy output from wrangler artifacts", async () => {
+			mock({
+				testOutputDir: {
+					"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+                    {"version": 1, "type":"wrangler-session", "wrangler_version":"3.81.0", "command_line_args":["what's up"], "log_file_path": "/here"}
+                    {"version": 1, "type":"pages-deploy-detailed", "pages_project": "project", "environment":"production", "alias":"test.com", "deployment_id": "123", "url":"url.com"}`,
+					"not-wrangler-output.json": "test",
+				},
+			});
+
+			const artifacts = await getDetailedPagesDeployOutput("./testOutputDir");
+
+			expect(artifacts).toEqual({
+				version: 1,
+				pages_project: "project",
+				type: "pages-deploy-detailed",
+				url: "url.com",
+				environment: "production",
+				deployment_id: "123",
+				alias: "test.com",
+			});
+			//mock.restore();
+		}),
+			it("Skips artifact entries that are not parseable", async () => {
+				mock({
+					testOutputDir: {
+						"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+                    this line is invalid json.
+                    {"version": 1, "type":"pages-deploy-detailed", "pages_project": "project", "environment":"production", "alias":"test.com", "deployment_id": "123", "url":"url.com"}`,
+						"not-wrangler-output.json": "test",
+					},
+				});
+
+				const artifacts = await getDetailedPagesDeployOutput("./testOutputDir");
+
+				expect(artifacts).toEqual({
+					version: 1,
+					type: "pages-deploy-detailed",
+					pages_project: "project",
+					url: "url.com",
+					environment: "production",
+					deployment_id: "123",
+					alias: "test.com",
+				});
+				//mock.restore();
+			});
+	});
+});

--- a/src/wranglerArtifactManager.ts
+++ b/src/wranglerArtifactManager.ts
@@ -1,0 +1,86 @@
+import { access, open, readdir } from "fs/promises";
+import { z } from "zod";
+
+const OutputEntryBase = z.object({
+	version: z.literal(1),
+	type: z.string(),
+});
+
+const OutputEntryPagesDeployment = OutputEntryBase.merge(
+	z.object({
+		type: z.literal("pages-deploy-detailed"),
+		pages_project: z.string().nullable(),
+		deployment_id: z.string().nullable(),
+		url: z.string().optional(),
+		alias: z.string().optional(),
+		environment: z.enum(["production", "preview"]),
+	}),
+);
+
+type OutputEntryPagesDeployment = z.infer<typeof OutputEntryPagesDeployment>;
+
+/**
+ * Parses file names in a directory to find wrangler artifact files
+ *
+ * @param artifactDirectory
+ * @returns All artifact files from the directory
+ */
+export async function getWranglerArtifacts(
+	artifactDirectory: string,
+): Promise<string[]> {
+	try {
+		await access(artifactDirectory);
+	} catch {
+		return [];
+	}
+
+	// read files in asset directory
+	const dirent = await readdir(artifactDirectory, {
+		withFileTypes: true,
+		recursive: false,
+	});
+
+	//  Match files to wrangler-output-<timestamp>-xxxxxx.json
+	const regex = new RegExp(
+		/^wrangler-output-[\d]{4}-[\d]{2}-[\d]{2}_[\d]{2}-[\d]{2}-[\d]{2}_[\d]{3}-[A-Fa-f0-9]{6}\.json$/,
+	);
+	const artifactFilePaths = dirent
+		.filter((d) => d.name.match(regex))
+		.map((d) => `${artifactDirectory}/${d.name}`);
+
+	return artifactFilePaths;
+}
+
+/**
+ * Searches for detailed wrangler output from a pages deploy
+ *
+ * @param artifactDirectory
+ * @returns The first pages-output-detailed found within a wrangler artifact directory
+ */
+export async function getDetailedPagesDeployOutput(
+	artifactDirectory: string,
+): Promise<OutputEntryPagesDeployment | null> {
+	const artifactFilePaths = await getWranglerArtifacts(artifactDirectory);
+
+	for (let i = 0; i < artifactFilePaths.length; i++) {
+		const file = await open(artifactFilePaths[i], "r");
+
+		for await (const line of file.readLines()) {
+			try {
+				const output = JSON.parse(line);
+				const parsedOutput = OutputEntryPagesDeployment.parse(output);
+				if (parsedOutput.type === "pages-deploy-detailed") {
+					// Assume, in the context of the action, the first detailed deploy instance seen will suffice
+					return parsedOutput;
+				}
+			} catch (err) {
+				// If the line can't be parsed, skip it
+				continue;
+			}
+		}
+
+		await file.close();
+	}
+
+	return null;
+}


### PR DESCRIPTION
Enables Pages deploys to provide outputs for id, environment, url, and alias, just like they can in pages-action. The current way of getting deploy outputs with Workers is via wrangler output to std out, but this information for Pages was not available in std out.

Because of that, this change adds a new method for getting outputs via wrangler artifacts.

The new outputs look like this in the Actions view.

When an alias is not available in the artifact:
![Screenshot 2024-10-18 at 2 38 10 PM](https://github.com/user-attachments/assets/da8d5510-fd4f-4de9-87b5-a6384f880f91)

When an alias is available in the artifact:
![Screenshot 2024-10-18 at 2 41 05 PM](https://github.com/user-attachments/assets/b9b34588-3ceb-430f-a9c3-7db0a389ff15)

When we don't get stuff back from the request for artifact:
![Screenshot 2024-10-21 at 10 14 05 AM](https://github.com/user-attachments/assets/d7386989-2bd9-4cd0-a10c-215becb52df7)
