### PR TITLE
⏪️ Restore previous Action outputs `deployment-url` and `deployment-alias-url` for Pages deployments

### DIFF
--- a/.changeset/eleven-maps-cheer.md
+++ b/.changeset/eleven-maps-cheer.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Restore previous Action outputs deployment-url and deployment-alias-url for Pages deployments

--- a/action.yml
+++ b/action.yml
@@ -53,3 +53,11 @@ outputs:
     description: "If the command was a Workers or Pages deployment, this will be the URL of the deployment"
   deployment-alias-url:
     description: "If the command was a Workers or Pages deployment, this can be the URL of the deployment alias (if it exists) - needs wrangler >= 3.78.0"
+  id:
+    description: "If the command was a Pages deployment, the deployment ID"
+  url:
+    description: "If the command was a Pages deployment, the URL of the pages deployment"
+  alias:
+    description: "If the command was a Pages deployment, the alias if it exists otherwise the deployment URL"
+  environment:
+    description: "If the command was a Pages deployment, the environment that was deployed to"

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,8 +367,12 @@ async function wranglerCommands() {
 				if (pagesArtifactFields) {
 					setOutput("id", pagesArtifactFields.deployment_id);
 					setOutput("url", pagesArtifactFields.url);
+					// For compatibility with previous versions of the action
+					setOutput("deployment-url", pagesArtifactFields.url);
 					// To ensure parity with pages-action, display url for alias if there is no alias
 					setOutput("alias", pagesArtifactFields.alias);
+					// For compatibility with previous versions of the action
+					setOutput("deployment-alias-url", pagesArtifactFields.alias);
 					setOutput("environment", pagesArtifactFields.environment);
 				} else {
 					info(


### PR DESCRIPTION
⏪️ Restore previous Action outputs `deployment-url` and `deployment-alias-url` for Pages deployments

## Description

When a deployment is a Pages deployment, https://github.com/cloudflare/wrangler-action/pull/303 (accidentally, I think) removed the exiting GitHub Action output `deployment-url` and `deployment-alias-url`.

This was released in version 3.10 and caused https://github.com/cloudflare/wrangler-action/issues/307

I found it while debugging how I use it in the FastAPI docs previews: https://github.com/fastapi/fastapi/pull/12526#issuecomment-2434910233

## Solution

This PR restores including the existing output variables even when the command is a Pages deployment (keeping the new output variables too). It also documents the new output of the Action in the `action.yml` schema.

## Next Steps

Not sure about the process for testing, not sure if this would be included in your tests, I'll leave this up to you.

Feel free to take over this PR and add things on top, or copy the code somewhere else, etc. All's good. :sweat_smile: 

I think the first person to give this a first review would be @courtney-sims :nerd_face: 