### PR TITLE
Use random UUID when creating wrangler artifacts output directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,10 @@ const config = {
 	COMMANDS: getMultilineInput("command"),
 	QUIET_MODE: getBooleanInput("quiet"),
 	PACKAGE_MANAGER: getInput("packageManager"),
-	WRANGLER_OUTPUT_DIR: `${join(tmpdir(), "wranglerArtifacts")}`,
+	WRANGLER_OUTPUT_DIR: `${join(
+		tmpdir(),
+		`wranglerArtifacts-${crypto.randomUUID()}`,
+	)}`,
 } as const;
 
 const packageManager = getPackageManager(config.PACKAGE_MANAGER, {


### PR DESCRIPTION
Addresses #317,

Problem: If a user runs wrangler-action multiple times we'll return the wrong `deployment-url`, as we only return the first detailed deployment instance from the artifact file.

Solution: Let's generate a new output directory with a randomUUID in the tmpDir, so that when the action is ran multiple times, we use the artifacts from that run, opposed to the artifacts from a previous run.

Tested here: 
[Returns correct output for first run](https://github.com/Maximo-Guk/demo-actions/actions/runs/11692341714/job/32561485822#step:5:9)
[Returns correct output for second run ](https://github.com/Maximo-Guk/demo-actions/actions/runs/11692341714/job/32561485822#step:7:10)