### PR TITLE
Bump default wrangler version to 3.90.0

### DIFF
--- a/.changeset/rich-maps-hide.md
+++ b/.changeset/rich-maps-hide.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Bump default wrangler version to 3.90.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { getPackageManager } from "./packageManagers";
 import { checkWorkingDirectory } from "./utils";
 import { main, WranglerActionConfig } from "./wranglerAction";
 
-const DEFAULT_WRANGLER_VERSION = "3.81.0";
+const DEFAULT_WRANGLER_VERSION = "3.90.0";
 
 /**
  * A configuration object that contains all the inputs & immutable state for the action.

--- a/src/wranglerArtifactManager.ts
+++ b/src/wranglerArtifactManager.ts
@@ -14,9 +14,9 @@ const OutputEntryPagesDeployment = OutputEntryBase.merge(
 		url: z.string().optional(),
 		alias: z.string().optional(),
 		environment: z.enum(["production", "preview"]),
-		// optional, added in wrangler@TBD
+		// optional, added in wrangler@3.89.0
 		production_branch: z.string().optional(),
-		// optional, added in wrangler@TBD
+		// optional, added in wrangler@3.89.0
 		stages: z
 			.array(
 				z.object({
@@ -40,7 +40,7 @@ const OutputEntryPagesDeployment = OutputEntryBase.merge(
 				}),
 			)
 			.optional(),
-		// optional, added in wrangler@TBD
+		// optional, added in wrangler@3.89.0
 		deployment_trigger: z
 			.object({
 				metadata: z.object({


### PR DESCRIPTION
Bumping wrangler so that we can use the new artifacts released in 3.89.0 for github deployments and job summaries (#325)