### PR TITLE
Update secret upload command to use `secret bulk`

### DIFF
--- a/.changeset/stale-crabs-search.md
+++ b/.changeset/stale-crabs-search.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Use `secret bulk` instead of deprecated `secret:bulk` command

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -266,7 +266,7 @@ async function uploadSecrets(
 			);
 		}
 
-		const args = ["wrangler", "secret:bulk"];
+		const args = ["wrangler", "secret", "bulk"];
 
 		if (environment) {
 			args.push("--env", environment);


### PR DESCRIPTION
Replace the deprecated `secret:bulk` command with the updated `secret bulk` command for uploading secrets.