### PR TITLE
fix: pages github deployment not triggering due to incorrect condition

### DIFF
--- a/src/service/github.ts
+++ b/src/service/github.ts
@@ -92,8 +92,7 @@ export async function createGitHubDeploymentAndJobSummary(
 		config.GITHUB_TOKEN &&
 		pagesArtifactFields.production_branch &&
 		pagesArtifactFields.pages_project &&
-		pagesArtifactFields.deployment_trigger &&
-		pagesArtifactFields.stages
+		pagesArtifactFields.deployment_trigger
 	) {
 		const octokit = getOctokit(config.GITHUB_TOKEN);
 		await Promise.all([


### PR DESCRIPTION
## Description

After a few tries on different repos, and after a migration from `cloudflare/pages-action` to `cloudflare/wrangler-action`, the feature to add Github deployment and summary is not working.

## How to reproduce
```bash
# Force a wrangler deploy similar to CI
CLOUDFLARE_API_TOKEN=xxx WRANGLER_OUTPUT_FILE_DIRECTORY=tmp CI=true \
npx wrangler pages deploy ./dist --project-name=my-project --branch=test/branch-deployment
# Checking stages key
cat tmp/wrangler-output-xxx.json | jq 'select(.type == "pages-deploy-detailed") | .stages'
# null
```

## Solution

Remove the conditional for `stages` as it's optional, not used in the action and currently preventing the Summary/Deployment to be generated.
