### PR TITLE
fix: pages github deployment not triggering due to incorrect condition #2

### DIFF
--- a/.changeset/tiny-pillows-return.md
+++ b/.changeset/tiny-pillows-return.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+fix: Pages GitHub Deployment not triggering

--- a/src/service/github.ts
+++ b/src/service/github.ts
@@ -92,8 +92,7 @@ export async function createGitHubDeploymentAndJobSummary(
 		config.GITHUB_TOKEN &&
 		pagesArtifactFields.production_branch &&
 		pagesArtifactFields.pages_project &&
-		pagesArtifactFields.deployment_trigger &&
-		pagesArtifactFields.stages
+		pagesArtifactFields.deployment_trigger
 	) {
 		const octokit = getOctokit(config.GITHUB_TOKEN);
 		await Promise.all([

--- a/src/wranglerArtifactManager.ts
+++ b/src/wranglerArtifactManager.ts
@@ -17,30 +17,6 @@ const OutputEntryPagesDeployment = OutputEntryBase.merge(
 		// optional, added in wrangler@3.89.0
 		production_branch: z.string().optional(),
 		// optional, added in wrangler@3.89.0
-		stages: z
-			.array(
-				z.object({
-					name: z.enum([
-						"queued",
-						"initialize",
-						"clone_repo",
-						"build",
-						"deploy",
-					]),
-					status: z.enum([
-						"idle",
-						"active",
-						"canceled",
-						"success",
-						"failure",
-						"skipped",
-					]),
-					started_on: z.string().nullable(),
-					ended_on: z.string().nullable(),
-				}),
-			)
-			.optional(),
-		// optional, added in wrangler@3.89.0
 		deployment_trigger: z
 			.object({
 				metadata: z.object({


### PR DESCRIPTION
See #344.

Just opening a new PR so that I could add a changeset and remove stages field from the zod schema. This field was never added in the original wrangler PR. https://github.com/cloudflare/workers-sdk/pull/7252