### PR TITLE
Fix: set deployment-url for "versions upload" command

### DIFF
--- a/.changeset/afraid-clocks-tan.md
+++ b/.changeset/afraid-clocks-tan.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Set deployment-url for "versions upload" command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wrangler-action",
-	"version": "3.12.1",
+	"version": "3.13.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.12.1",
+			"version": "3.13.0",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -379,8 +379,12 @@ async function wranglerCommands(
 			setOutput("command-output", stdOut);
 			setOutput("command-stderr", stdErr);
 
-			// Check if this command is a workers deployment
-			if (command.startsWith("deploy") || command.startsWith("publish")) {
+			// Check if this command is a workers deployment or a version upload
+			if (
+				command.startsWith("deploy") ||
+				command.startsWith("publish") ||
+				command.startsWith("versions upload")
+			) {
 				const { deploymentUrl } = extractDeploymentUrlsFromStdout(stdOut);
 				setOutput("deployment-url", deploymentUrl);
 			}


### PR DESCRIPTION
Fixes #343 

Simply extend the check to pull `deployment-url` from stdout if the command is `versions upload`.