### PR TITLE
feat: add `version-id` to action output of "version upload" command

### DIFF
--- a/.changeset/fluffy-knives-yell.md
+++ b/.changeset/fluffy-knives-yell.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Add `version-id` to GitHub Action output when using the `wrangler version upload` command.

--- a/action.yml
+++ b/action.yml
@@ -60,3 +60,5 @@ outputs:
     description: "If the command was a Pages deployment, this will be the ID of the deployment - needs wrangler >= 3.81.0"
   pages-environment:
     description: "If the command was a Pages deployment, this will be the environment of the deployment - needs wrangler >= 3.81.0"
+  version-id:
+    description: "If the command was a Workers version upload, this will be the ID of the version"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wrangler-action",
-	"version": "3.13.1",
+	"version": "3.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.13.1",
+			"version": "3.14.0",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/src/commandOutputParsing.ts
+++ b/src/commandOutputParsing.ts
@@ -112,6 +112,7 @@ function handleVersionsUploadOutputEntry(
 	versionsOutputEntry: OutputEntryVersionUpload,
 ) {
 	setOutput("deployment-url", versionsOutputEntry.preview_url);
+	setOutput("version-id", versionsOutputEntry.version_id);
 }
 
 /**

--- a/src/wranglerArtifactManager.ts
+++ b/src/wranglerArtifactManager.ts
@@ -45,6 +45,8 @@ export type OutputEntryVersionUpload = z.infer<typeof OutputEntryVersionUpload>;
 const OutputEntryVersionUpload = OutputEntryBase.merge(
 	z.object({
 		type: z.literal("version-upload"),
+		/** The id of this uploaded version */
+		version_id: z.string().uuid().optional(),
 		/** The preview URL associated with this version upload */
 		preview_url: z.string().optional(),
 	}),


### PR DESCRIPTION
This Pull Request adds a new GitHub Action output `version-id` referring to the new version uploaded with `wrangler versions upload`.

The use-case is to be able to run the Wrangler action to upload a new Worker version, and then run it again to deploy that version, for example:

```yaml
      - name: Upload new Worker version
        id: upload
        uses: cloudflare/wrangler-action@v3
        with:
          command: versions upload --tag "${{ github.ref_name }}"
      - name: Deploy new Worker version to 100%
        uses: cloudflare/wrangler-action@v3
        with:
          command: versions deploy "${{ steps.upload.outputs.version-id }}@100%"
```