### PR TITLE
Bump default wrangler version to 3.91.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { getPackageManager } from "./packageManagers";
 import { checkWorkingDirectory } from "./utils";
 import { main, WranglerActionConfig } from "./wranglerAction";
 
-const DEFAULT_WRANGLER_VERSION = "3.90.0";
+const DEFAULT_WRANGLER_VERSION = "3.91.0";
 
 /**
  * A configuration object that contains all the inputs & immutable state for the action.


### PR DESCRIPTION
# Add support for `wrangler.jsonc` by upgrading to wrangler v3.91.0+

## Issue
When using the [official GitHub Actions deployment script](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/) with a wrangler.jsonc file, the build fails unexpectedly. Error as follows: 
```
You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`
```

## Reproduction steps:

### Project structure:
> Auto generated by `npm create hono@latest`


```
├── package.json
├── src
│   └── index.ts
├── wrangler.jsonc  # Uses JSONC format
└── ...
```

### Deploy
Run the GitHub Actions workflow from the [Cloudflare documentation](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/):
```yaml

- uses: cloudflare/wrangler-action@v3
  with:
    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

```
### Result

Build fails due to unrecognized wrangler.jsonc support in older Wrangler versions.

## Solution
Upgrade Wrangler to v3.91.0+ to resolve compatibility with wrangler.jsonc. This aligns with the [community-reported issue #203 ](https://github.com/cloudflare/wrangler-action/issues/203#issuecomment-2813385601) and ensures the action works as expected with modern configuration files.

## Impact
- Fixes deployment failures for projects using wrangler.jsonc.
- Maintains backward compatibility with wrangler.json.