### PR TITLE
Add wranglerOutputDir input to customize artifact location

### DIFF
--- a/.changeset/rare-ladybugs-ring.md
+++ b/.changeset/rare-ladybugs-ring.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Add `wranglerOutputDir` input to customize artifact location

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ jobs:
         workingDirectory: "subfoldername"
 ```
 
+You can also specify the directory where Wrangler should place its output artifacts using `wranglerOutputDir`. By default, it uses a temporary directory.
+
+```yaml
+jobs:
+  deploy:
+    steps:
+      uses: cloudflare/wrangler-action@v3
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        wranglerOutputDir: "./dist"
+```
+
 [Worker secrets](https://developers.cloudflare.com/workers/tooling/wrangler/secrets/) can optionally be passed in via `secrets` as a string of names separated by newlines. Each secret name must match the name of an environment variable specified in the `env` field. This creates or replaces the value for the Worker secret using the `wrangler secret put` command. It's also possible to specify worker environment using environment parameter.
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
   packageManager:
     description: "The package manager you'd like to use to install and run wrangler. If not specified, the preferred package manager will be inferred based on the presence of a lockfile or fallback to using npm if no lockfile is found. Valid values are `npm` | `pnpm` | `yarn` | `bun`."
     required: false
+  wranglerOutputDir:
+    description: The directory where Wrangler should place its output artifacts. Defaults to a temporary directory.
+    required: false
   gitHubToken:
     description: "GitHub Token"
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,9 @@ const config: WranglerActionConfig = {
 	COMMANDS: getMultilineInput("command"),
 	QUIET_MODE: getBooleanInput("quiet"),
 	PACKAGE_MANAGER: getInput("packageManager"),
-	WRANGLER_OUTPUT_DIR: `${join(
-		tmpdir(),
-		`wranglerArtifacts-${crypto.randomUUID()}`,
-	)}`,
+	WRANGLER_OUTPUT_DIR:
+		getInput("wranglerOutputDir") ||
+		`${join(tmpdir(), `wranglerArtifacts-${crypto.randomUUID()}`)}`,
 	GITHUB_TOKEN: getInput("gitHubToken", { required: false }),
 } as const;
 


### PR DESCRIPTION
This PR introduces the optional `wranglerOutputDir` input.

This allows users to specify a custom directory for Wrangler's output artifacts.
The primary motivation is to enable uploading these artifacts using `actions/upload-artifact` in subsequent workflow steps.