### PR TITLE
add config opt to use `versions secret bulk`

### DIFF
--- a/.changeset/warm-impalas-roll.md
+++ b/.changeset/warm-impalas-roll.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Add option to use `versions secret bulk` for secrets

--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ jobs:
         workingDirectory: "subfoldername"
 ```
 
-[Worker secrets](https://developers.cloudflare.com/workers/tooling/wrangler/secrets/) can optionally be passed in via `secrets` as a string of names separated by newlines. Each secret name must match the name of an environment variable specified in the `env` field. This creates or replaces the value for the Worker secret using the `wrangler secret put` command. It's also possible to specify worker environment using environment parameter.
+[Worker secrets](https://developers.cloudflare.com/workers/tooling/wrangler/secrets/) can optionally be passed in via `secrets` as a string of names separated by newlines. Each secret name must match the name of an environment variable specified in the `env` field. This upserts the value for the Worker secret. It's also possible to specify worker environment using environment parameter.
+
+The default command used to upsert is `wrangler secret bulk` for `wrangler` versions >= `3.4.0`. This command attempts to deploy the latest version with modified settings. For `wrangler` versions >= `3.62.0`, run the action with `useVersionsSecrets: true` to run `wrangler versions secret bulk` which creates a new version without a deployment.
+
+For `wrangler` versions < `3.4.0`, the command used for secrets is `wrangler secret put`.
 
 ```yaml
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
   gitHubToken:
     description: "GitHub Token"
     required: false
+  useVersionSecrets:
+    description: "Use the `versions secret bulk` command to upload secrets. This will create a new version without deploying it when uploading secrets. This is only available for wrangler >= 3.62.0."
+    required: false
+    default: "false"
 outputs:
   command-output:
     description: "The output of the Wrangler command (comes from stdout)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wrangler-action",
-	"version": "3.13.1",
+	"version": "3.14.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.13.1",
+			"version": "3.14.1",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const config: WranglerActionConfig = {
 	didUserProvideWranglerVersion: Boolean(getInput("wranglerVersion")),
 	secrets: getMultilineInput("secrets"),
 	workingDirectory: checkWorkingDirectory(getInput("workingDirectory")),
+	useVersionsSecrets: getBooleanInput("useVersionSecrets"),
 	CLOUDFLARE_API_TOKEN: getInput("apiToken"),
 	CLOUDFLARE_ACCOUNT_ID: getInput("accountId"),
 	ENVIRONMENT: getInput("environment"),

--- a/src/wranglerAction.test.ts
+++ b/src/wranglerAction.test.ts
@@ -162,4 +162,50 @@ describe("uploadSecrets", () => {
 		expect(startGroup).toBeCalledWith("🔑 Uploading secrets...");
 		expect(endGroup).toHaveBeenCalledOnce();
 	});
+
+	it("WRANGLER_VERSION 3.62.0 can use wrangler versions secret bulk", async () => {
+		vi.stubEnv("FAKE_SECRET", "FAKE_VALUE");
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "3.62.0",
+				didUserProvideWranglerVersion: true,
+				useVersionsSecrets: true,
+				secrets: ["FAKE_SECRET"],
+			},
+		});
+		vi.spyOn(exec, "exec").mockImplementation(async (cmd, args) => {
+			expect(cmd).toBe("npx");
+			expect(args).toStrictEqual([
+				"wrangler",
+				"versions",
+				"secret",
+				"bulk",
+				"--env",
+				"dev",
+			]);
+			return 0;
+		});
+		const startGroup = vi.spyOn(core, "startGroup");
+		const endGroup = vi.spyOn(core, "endGroup");
+
+		await uploadSecrets(testConfig, testPackageManager);
+		expect(startGroup).toBeCalledWith("🔑 Uploading secrets...");
+		expect(endGroup).toHaveBeenCalledOnce();
+	});
+
+	it("WRANGLER_VERSION 3.61.0 cannot use wrangler versions secret bulk", async () => {
+		vi.stubEnv("FAKE_SECRET", "FAKE_VALUE");
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "3.61.0",
+				didUserProvideWranglerVersion: true,
+				useVersionsSecrets: true,
+				secrets: ["FAKE_SECRET"],
+			},
+		});
+
+		expect(uploadSecrets(testConfig, testPackageManager)).rejects.toThrowError(
+			/3\.62\.0/,
+		);
+	});
 });

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -19,6 +19,7 @@ export type WranglerActionConfig = z.infer<typeof wranglerActionConfig>;
 export const wranglerActionConfig = z.object({
 	WRANGLER_VERSION: z.string(),
 	didUserProvideWranglerVersion: z.boolean(),
+	useVersionsSecrets: z.boolean(),
 	secrets: z.array(z.string()),
 	workingDirectory: z.string(),
 	CLOUDFLARE_API_TOKEN: z.string(),
@@ -253,6 +254,15 @@ async function uploadSecrets(
 		return;
 	}
 
+	if (
+		semverLt(config["WRANGLER_VERSION"], "3.62.0") &&
+		config["useVersionsSecrets"]
+	) {
+		throw new Error(
+			"Wrangler version 3.62.0 or greater is required to use `versions secret bulk`",
+		);
+	}
+
 	startGroup(config, "🔑 Uploading secrets...");
 
 	try {
@@ -270,6 +280,10 @@ async function uploadSecrets(
 		// if we're on a WRANGLER_VERSION prior to 3.60.0 use wrangler secret:bulk
 		if (semverLt(config["WRANGLER_VERSION"], "3.60.0")) {
 			args = ["wrangler", "secret:bulk"];
+		}
+
+		if (config["useVersionsSecrets"]) {
+			args = ["wrangler", "versions", "secret", "bulk"];
 		}
 
 		if (environment) {


### PR DESCRIPTION
relates to [this issue](https://github.com/cloudflare/wrangler-action/issues/374) and the [workaround comment here](https://github.com/cloudflare/wrangler-action/issues/374#issuecomment-3258265218).

it seems it would be ideal to use this command, but I think it would be a breaking change to do so by default