### PR TITLE
fix: normalize deployment-url output to remove suffix and ensure protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wrangler-action",
-	"version": "3.13.1",
+	"version": "3.14.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.13.1",
+			"version": "3.14.1",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/src/commandOutputParsing.test.ts
+++ b/src/commandOutputParsing.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleWranglerDeployOutputEntry } from "./commandOutputParsing";
+import { setOutput } from "@actions/core";
+import { WranglerActionConfig } from "./wranglerAction";
+import { OutputEntryDeployment } from "./wranglerArtifactManager";
+
+vi.mock("@actions/core");
+vi.mock("./wranglerAction", () => ({
+    info: vi.fn(),
+}));
+
+describe("handleWranglerDeployOutputEntry", () => {
+    const mockConfig = {} as WranglerActionConfig;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should handle clean URL", () => {
+        const entry: OutputEntryDeployment = {
+            version: 1,
+            type: "deploy",
+            targets: ["https://example.com"],
+        };
+        handleWranglerDeployOutputEntry(mockConfig, entry);
+        expect(setOutput).toHaveBeenCalledWith("deployment-url", "https://example.com");
+    });
+
+    it("should handle URL without protocol", () => {
+        const entry: OutputEntryDeployment = {
+            version: 1,
+            type: "deploy",
+            targets: ["example.com"],
+        };
+        handleWranglerDeployOutputEntry(mockConfig, entry);
+        expect(setOutput).toHaveBeenCalledWith("deployment-url", "https://example.com");
+    });
+
+    it("should handle URL with extra text (custom domain)", () => {
+        const entry: OutputEntryDeployment = {
+            version: 1,
+            type: "deploy",
+            targets: ["example.com (custom domain)"],
+        };
+        handleWranglerDeployOutputEntry(mockConfig, entry);
+        expect(setOutput).toHaveBeenCalledWith("deployment-url", "https://example.com");
+    });
+
+    it("should handle URL with extra text and protocol", () => {
+        const entry: OutputEntryDeployment = {
+            version: 1,
+            type: "deploy",
+            targets: ["https://foo.bar (Custom)"],
+        };
+        handleWranglerDeployOutputEntry(mockConfig, entry);
+        expect(setOutput).toHaveBeenCalledWith("deployment-url", "https://foo.bar");
+    });
+
+    it("should take the first URL if multiple are present", () => {
+        const entry: OutputEntryDeployment = {
+            version: 1,
+            type: "deploy",
+            targets: ["https://primary.com", "https://secondary.com"],
+        };
+        handleWranglerDeployOutputEntry(mockConfig, entry);
+        expect(setOutput).toHaveBeenCalledWith("deployment-url", "https://primary.com");
+    });
+});

--- a/src/commandOutputParsing.ts
+++ b/src/commandOutputParsing.ts
@@ -67,7 +67,7 @@ function handlePagesDeployCommand(
 	setOutput("pages-deployment-alias-url", aliasUrl);
 }
 
-function handleWranglerDeployOutputEntry(
+export function handleWranglerDeployOutputEntry(
 	config: WranglerActionConfig,
 	wranglerDeployOutputEntry: OutputEntryDeployment,
 ) {
@@ -89,7 +89,28 @@ function handleWranglerDeployOutputEntry(
 		);
 	}
 
-	setOutput("deployment-url", wranglerDeployOutputEntry.targets[0]);
+	let deploymentUrl = (wranglerDeployOutputEntry.targets?.[0] ?? "").trim();
+
+	// Clean up suffix annotations like "(...)"
+	deploymentUrl = deploymentUrl.replace(/\s*\([^)]*\)\s*$/, "");
+
+	// Add protocol if missing
+	if (deploymentUrl && !/^https?:\/\//i.test(deploymentUrl)) {
+		deploymentUrl = `https://${deploymentUrl}`;
+	}
+
+	// Validate
+	try {
+		const u = new URL(deploymentUrl);
+		deploymentUrl =
+			u.pathname === "/" && !u.search && !u.hash ? u.origin : u.toString();
+	} catch {
+		deploymentUrl = "";
+	}
+
+	if (deploymentUrl) {
+		setOutput("deployment-url", deploymentUrl);
+	}
 }
 
 /**


### PR DESCRIPTION
The `deployment-url` output may include a suffix such as `(custom domain)` or be missing the protocol, resulting in an invalid URL.
- Removed trailing suffixes like `(custom domain)`
- Ensured the URL includes the `https://` protocol
- Normalized the output to produce a valid, usable URL
- Added unit tests covering the affected scenarios
- All tests pass successfully
Fixes #396