### PR TITLE
docs: update README environment parameter examples

### DIFF
--- a/.changeset/update-readme-env-examples.md
+++ b/.changeset/update-readme-env-examples.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Update README examples to use `environment` parameter instead of `--env` flag

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: deploy --env ${{ github.event.inputs.environment }}
+          command: deploy
+          environment: ${{ github.event.inputs.environment }}  
 ```
 
 For more advanced usage or to programmatically trigger the workflow from scripts, refer to [the GitHub documentation](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event) for making API calls.
@@ -267,7 +268,7 @@ There is an environment parameter that can be set within the workflow to enable 
 - uses: cloudflare/wrangler-action@v3
   with:
     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    command: deploy --env production
+    command: deploy
     secrets: |
       SUPER_SECRET
     environment: production


### PR DESCRIPTION
## Summary
 - Update README examples to use `environment` parameter instead of `--env` flag in command
 - This provides clearer guidance on the recommended way to specify environments

 ## Changes
 - Updated workflow dispatch example to use separate `environment` parameter
 - Updated secrets example to use separate `environment` parameter instead of inline `--env` flag
