### PR TITLE
Upgrade Node.js runtime to v24

### DIFF
--- a/.changeset/wicked-donuts-fold.md
+++ b/.changeset/wicked-donuts-fold.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": major
+---
+
+Upgrade Node.js runtime to v24

--- a/.changeset/wicked-donuts-fold.md
+++ b/.changeset/wicked-donuts-fold.md
@@ -1,5 +1,5 @@
 ---
-"wrangler-action": major
+"wrangler-action": patch
 ---
 
 Upgrade Node.js runtime to v24

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
 description: "Deploy your Cloudflare projects from GitHub using Wrangler"
 runs:
   # Possible values: https://github.com/actions/runner/blob/main/src/Runner.Common/Util/NodeUtil.cs#L9
-  using: "node20"
+  using: "node24"
   main: "dist/index.mjs"
 inputs:
   apiToken:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wrangler-action",
-	"version": "3.13.1",
+	"version": "3.14.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.13.1",
+			"version": "3.14.1",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.11.1",


### PR DESCRIPTION
The Node.js v20 runtime has been deprecated: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
This suppresses the warning on users.