### PR TITLE
Default to Wrangler v4 and upgrade to Node.js 24

### DIFF
--- a/.changeset/v4-node24-updates.md
+++ b/.changeset/v4-node24-updates.md
@@ -1,5 +1,5 @@
 ---
-"wrangler-action": minor
+"wrangler-action": major
 ---
 
 Default to Wrangler v4 with a new `wranglerMajorVersion` input to allow pinning to v3. Upgrade action runtime to node24 and CI workflows to Node.js 24.

--- a/.changeset/v4-node24-updates.md
+++ b/.changeset/v4-node24-updates.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Default to Wrangler v4 with a new `wranglerMajorVersion` input to allow pinning to v3. Upgrade action runtime to node24 and CI workflows to Node.js 24.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,13 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          # Pinned due to compatibility issues on 23.2.0
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install modules and build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,15 @@ jobs:
       issues: read
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          # Pinned due to compatibility issues on 23.2.0
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install modules

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,5 +20,5 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: semgrep ci

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
 description: "Deploy your Cloudflare projects from GitHub using Wrangler"
 runs:
   # Possible values: https://github.com/actions/runner/blob/main/src/Runner.Common/Util/NodeUtil.cs#L9
-  using: "node20"
+  using: "node24"
   main: "dist/index.mjs"
 inputs:
   apiToken:
@@ -24,8 +24,12 @@ inputs:
     description: "The relative path which Wrangler commands should be run from"
     required: false
   wranglerVersion:
-    description: "The version of Wrangler you'd like to use to deploy your Workers project"
+    description: "The exact version of Wrangler you'd like to use to deploy your Workers project. Takes precedence over wranglerMajorVersion."
     required: false
+  wranglerMajorVersion:
+    description: "The major version of Wrangler to use. Set to '3' to pin to the latest Wrangler v3 release. Defaults to '4'."
+    required: false
+    default: "4"
   secrets:
     description: "A string of environment variable names, separated by newlines. These will be bound to your Worker as Secrets and must match the names of environment variables declared in `env` of this workflow."
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wrangler-action",
-	"version": "3.13.1",
+	"version": "3.14.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wrangler-action",
-			"version": "3.13.1",
+			"version": "3.14.1",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,22 @@ import { getPackageManager } from "./packageManagers";
 import { checkWorkingDirectory } from "./utils";
 import { main, WranglerActionConfig } from "./wranglerAction";
 
-const DEFAULT_WRANGLER_VERSION = "3.90.0";
+const DEFAULT_WRANGLER_V4_VERSION = "4.79.0";
+const DEFAULT_WRANGLER_V3_VERSION = "3.114.17";
+
+function getDefaultWranglerVersion(): string {
+	const majorVersion = getInput("wranglerMajorVersion") || "4";
+	return majorVersion === "3"
+		? DEFAULT_WRANGLER_V3_VERSION
+		: DEFAULT_WRANGLER_V4_VERSION;
+}
 
 /**
  * A configuration object that contains all the inputs & immutable state for the action.
  */
 const config: WranglerActionConfig = {
-	WRANGLER_VERSION: getInput("wranglerVersion") || DEFAULT_WRANGLER_VERSION,
+	WRANGLER_VERSION:
+		getInput("wranglerVersion") || getDefaultWranglerVersion(),
 	didUserProvideWranglerVersion: Boolean(getInput("wranglerVersion")),
 	secrets: getMultilineInput("secrets"),
 	workingDirectory: checkWorkingDirectory(getInput("workingDirectory")),

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -7,7 +7,7 @@ export function getTestConfig({
 } = {}): WranglerActionConfig {
 	return Object.assign(
 		{
-			WRANGLER_VERSION: "3.81.0",
+			WRANGLER_VERSION: "4.79.0",
 			didUserProvideWranglerVersion: false,
 			secrets: [],
 			workingDirectory: "/src/test/fixtures",

--- a/src/wranglerAction.test.ts
+++ b/src/wranglerAction.test.ts
@@ -1,8 +1,25 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
-import { describe, expect, it, vi } from "vitest";
-import { installWrangler, uploadSecrets } from "./wranglerAction";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	authenticationSetup,
+	execCommands,
+	installWrangler,
+	uploadSecrets,
+	wranglerCommands,
+} from "./wranglerAction";
 import { getTestConfig } from "./test/test-utils";
+
+vi.mock("./commandOutputParsing", () => ({
+	handleCommandOutputParsing: vi.fn(),
+}));
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	delete process.env.CLOUDFLARE_API_TOKEN;
+	delete process.env.CLOUDFLARE_ACCOUNT_ID;
+	delete process.env.WRANGLER_OUTPUT_FILE_DIRECTORY;
+});
 
 describe("installWrangler", () => {
 	const testPackageManager = {
@@ -161,5 +178,298 @@ describe("uploadSecrets", () => {
 		await uploadSecrets(testConfig, testPackageManager);
 		expect(startGroup).toBeCalledWith("🔑 Uploading secrets...");
 		expect(endGroup).toHaveBeenCalledOnce();
+	});
+
+	it("Skips upload when secrets array is empty", async () => {
+		const testConfig = getTestConfig({
+			config: { secrets: [] },
+		});
+		const execSpy = vi.spyOn(exec, "exec");
+		await uploadSecrets(testConfig, testPackageManager);
+		expect(execSpy).not.toHaveBeenCalled();
+	});
+
+	it("Throws when secret value is not in environment", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "3.61.0",
+				secrets: ["MISSING_SECRET"],
+			},
+		});
+		vi.spyOn(exec, "exec").mockImplementation(async () => 0);
+		await expect(
+			uploadSecrets(testConfig, testPackageManager),
+		).rejects.toThrowError("Failed to upload secrets.");
+	});
+});
+
+describe("authenticationSetup", () => {
+	it("Sets CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID env vars", () => {
+		const testConfig = getTestConfig({
+			config: {
+				CLOUDFLARE_API_TOKEN: "test-api-token",
+				CLOUDFLARE_ACCOUNT_ID: "test-account-id",
+			},
+		});
+
+		authenticationSetup(testConfig);
+
+		expect(process.env.CLOUDFLARE_API_TOKEN).toBe("test-api-token");
+		expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBe("test-account-id");
+	});
+});
+
+describe("execCommands", () => {
+	const testPackageManager = {
+		install: "npm i",
+		exec: "npx",
+		execNoInstall: "npx --no-install",
+	};
+
+	it("Does nothing when commands array is empty", async () => {
+		const testConfig = getTestConfig();
+		const startGroupSpy = vi.spyOn(core, "startGroup");
+		await execCommands(testConfig, testPackageManager, [], "pre");
+		expect(startGroupSpy).not.toHaveBeenCalled();
+	});
+
+	it("Prefixes wrangler commands with package manager exec", async () => {
+		const testConfig = getTestConfig();
+		const execShellMock = vi.fn().mockResolvedValue(0);
+		vi.spyOn(await import("./exec"), "execShell").mockImplementation(
+			execShellMock,
+		);
+
+		await execCommands(
+			testConfig,
+			testPackageManager,
+			["wrangler dev"],
+			"pre",
+		);
+
+		expect(execShellMock).toHaveBeenCalledWith("npx wrangler dev", {
+			cwd: testConfig.workingDirectory,
+			silent: false,
+		});
+	});
+
+	it("Runs non-wrangler commands as-is", async () => {
+		const testConfig = getTestConfig();
+		const execShellMock = vi.fn().mockResolvedValue(0);
+		vi.spyOn(await import("./exec"), "execShell").mockImplementation(
+			execShellMock,
+		);
+
+		await execCommands(testConfig, testPackageManager, ["echo hello"], "post");
+
+		expect(execShellMock).toHaveBeenCalledWith("echo hello", {
+			cwd: testConfig.workingDirectory,
+			silent: false,
+		});
+	});
+
+	it("Runs multiple commands sequentially", async () => {
+		const testConfig = getTestConfig();
+		const callOrder: string[] = [];
+		vi.spyOn(await import("./exec"), "execShell").mockImplementation(
+			async (cmd) => {
+				callOrder.push(cmd as string);
+				return 0;
+			},
+		);
+
+		await execCommands(
+			testConfig,
+			testPackageManager,
+			["echo first", "echo second"],
+			"pre",
+		);
+
+		expect(callOrder).toEqual(["echo first", "echo second"]);
+	});
+});
+
+describe("wranglerCommands", () => {
+	const testPackageManager = {
+		install: "npm i",
+		exec: "npx",
+		execNoInstall: "npx --no-install",
+	};
+
+	it("Defaults to deploy command when no commands specified", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: [],
+				WRANGLER_VERSION: "3.81.0",
+				ENVIRONMENT: "",
+				VARS: [],
+			},
+		});
+		const execSpy = vi
+			.spyOn(exec, "exec")
+			.mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(execSpy).toHaveBeenCalledWith(
+			"npx wrangler deploy",
+			[],
+			expect.anything(),
+		);
+	});
+
+	it("Uses publish for wrangler versions before 2.20.0", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: [],
+				WRANGLER_VERSION: "2.19.0",
+				ENVIRONMENT: "",
+				VARS: [],
+			},
+		});
+		const execSpy = vi
+			.spyOn(exec, "exec")
+			.mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(execSpy).toHaveBeenCalledWith(
+			"npx wrangler publish",
+			[],
+			expect.anything(),
+		);
+	});
+
+	it("Appends --env flag when environment is set and not already in command", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: ["deploy"],
+				ENVIRONMENT: "staging",
+				VARS: [],
+			},
+		});
+		const execSpy = vi
+			.spyOn(exec, "exec")
+			.mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(execSpy).toHaveBeenCalledWith(
+			"npx wrangler deploy",
+			["--env", "staging"],
+			expect.anything(),
+		);
+	});
+
+	it("Does not duplicate --env flag when already in command", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: ["deploy --env production"],
+				ENVIRONMENT: "staging",
+				VARS: [],
+			},
+		});
+		const execSpy = vi
+			.spyOn(exec, "exec")
+			.mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(execSpy).toHaveBeenCalledWith(
+			"npx wrangler deploy --env production",
+			[],
+			expect.anything(),
+		);
+	});
+
+	it("Appends --var flags for deploy commands with VARS", async () => {
+		vi.stubEnv("MY_VAR", "my_value");
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: ["deploy"],
+				ENVIRONMENT: "",
+				VARS: ["MY_VAR"],
+			},
+		});
+		const execSpy = vi
+			.spyOn(exec, "exec")
+			.mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(execSpy).toHaveBeenCalledWith(
+			"npx wrangler deploy",
+			["--var", "MY_VAR:my_value"],
+			expect.anything(),
+		);
+	});
+
+	it("Does not append --var for non-deploy commands", async () => {
+		vi.stubEnv("MY_VAR", "my_value");
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: ["tail --format json"],
+				ENVIRONMENT: "",
+				VARS: ["MY_VAR"],
+			},
+		});
+		const execSpy = vi
+			.spyOn(exec, "exec")
+			.mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(execSpy).toHaveBeenCalledWith(
+			"npx wrangler tail --format json",
+			[],
+			expect.anything(),
+		);
+	});
+
+	it("Sets command-output and command-stderr outputs", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: ["deploy"],
+				ENVIRONMENT: "",
+				VARS: [],
+			},
+		});
+		vi.spyOn(exec, "exec").mockImplementation(
+			async (_cmd, _args, options) => {
+				options?.listeners?.stdout?.(Buffer.from("deploy output"));
+				options?.listeners?.stderr?.(Buffer.from("deploy warning"));
+				return 0;
+			},
+		);
+		const setOutputSpy = vi.spyOn(core, "setOutput");
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(setOutputSpy).toHaveBeenCalledWith(
+			"command-output",
+			"deploy output",
+		);
+		expect(setOutputSpy).toHaveBeenCalledWith(
+			"command-stderr",
+			"deploy warning",
+		);
+	});
+
+	it("Sets WRANGLER_OUTPUT_FILE_DIRECTORY env var", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				COMMANDS: ["deploy"],
+				ENVIRONMENT: "",
+				VARS: [],
+				WRANGLER_OUTPUT_DIR: "/custom/output/dir",
+			},
+		});
+		vi.spyOn(exec, "exec").mockImplementation(async () => 0);
+
+		await wranglerCommands(testConfig, testPackageManager);
+
+		expect(process.env.WRANGLER_OUTPUT_FILE_DIRECTORY).toBe(
+			"/custom/output/dir",
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- **Default to Wrangler v4**: The action now defaults to Wrangler v4 (`4.79.0`) instead of v3.
- **New `wranglerMajorVersion` input**: Users can set `wranglerMajorVersion: "3"` to pin to the latest v3 release (`3.114.17`). The explicit `wranglerVersion` input still takes precedence.
- **Upgrade action runtime**: `node20` → `node24`.
- **Upgrade CI workflows**: `actions/checkout@v6`, `actions/setup-node@v6`, Node.js 24.

## Migration

No action required for most users. If you need to stay on Wrangler v3, add:

```yaml
- uses: cloudflare/wrangler-action@v3
  with:
    wranglerMajorVersion: "3"
```

Or pin to an exact version as before:

```yaml
- uses: cloudflare/wrangler-action@v3
  with:
    wranglerVersion: "3.114.17"
```

## Changed files

| File | Change |
|------|--------|
| `action.yml` | Runtime `node24`, new `wranglerMajorVersion` input |
| `src/index.ts` | Version resolution logic for v3/v4 defaults |
| `src/test/test-utils.ts` | Default test version updated to `4.79.0` |
| `.github/workflows/*.yml` | CI bumped to checkout@v6, setup-node@v6, Node 24 |

## Test plan

- [ ] Verify default behavior installs Wrangler v4
- [ ] Verify `wranglerMajorVersion: "3"` installs latest v3
- [ ] Verify explicit `wranglerVersion` still takes precedence
- [ ] Confirm CI workflows pass on Node.js 24