### PR TITLE
Add version-id to step outputs for versions upload

### DIFF
--- a/.changeset/add-version-id-output.md
+++ b/.changeset/add-version-id-output.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Add `version-id` to step outputs for `wrangler versions upload` commands.

--- a/action.yml
+++ b/action.yml
@@ -60,3 +60,5 @@ outputs:
     description: "If the command was a Pages deployment, this will be the ID of the deployment - needs wrangler >= 3.81.0"
   pages-environment:
     description: "If the command was a Pages deployment, this will be the environment of the deployment - needs wrangler >= 3.81.0"
+  version-id:
+    description: "The version ID from a `wrangler versions upload` command"

--- a/src/commandOutputParsing.test.ts
+++ b/src/commandOutputParsing.test.ts
@@ -1,0 +1,74 @@
+import * as core from "@actions/core";
+import mockfs from "mock-fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleCommandOutputParsing } from "./commandOutputParsing";
+import { getTestConfig } from "./test/test-utils";
+
+vi.mock("./service/github", () => ({
+	createGitHubDeploymentAndJobSummary: vi.fn(),
+}));
+
+const testConfig = getTestConfig();
+
+afterEach(() => {
+	mockfs.restore();
+	vi.restoreAllMocks();
+});
+
+describe("handleCommandOutputParsing", () => {
+	describe("version-upload", () => {
+		it("Sets version-id output when version_id is present", async () => {
+			const setOutputSpy = vi.spyOn(core, "setOutput");
+
+			mockfs({
+				[testConfig.WRANGLER_OUTPUT_DIR]: {
+					"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+{"version": 1, "type":"wrangler-session", "wrangler_version":"3.88.0", "command_line_args":["versions","upload"], "log_file_path": "/here"}
+{"version": 1, "type":"version-upload", "preview_url": "https://preview.example.com", "version_id": "ver-abc-123"}`,
+				},
+			});
+
+			await handleCommandOutputParsing(
+				testConfig,
+				"versions upload",
+				"some stdout",
+			);
+
+			expect(setOutputSpy).toHaveBeenCalledWith(
+				"deployment-url",
+				"https://preview.example.com",
+			);
+			expect(setOutputSpy).toHaveBeenCalledWith(
+				"version-id",
+				"ver-abc-123",
+			);
+		});
+
+		it("Handles version-upload when version_id is missing", async () => {
+			const setOutputSpy = vi.spyOn(core, "setOutput");
+
+			mockfs({
+				[testConfig.WRANGLER_OUTPUT_DIR]: {
+					"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+{"version": 1, "type":"wrangler-session", "wrangler_version":"3.88.0", "command_line_args":["versions","upload"], "log_file_path": "/here"}
+{"version": 1, "type":"version-upload", "preview_url": "https://preview.example.com"}`,
+				},
+			});
+
+			await handleCommandOutputParsing(
+				testConfig,
+				"versions upload",
+				"some stdout",
+			);
+
+			expect(setOutputSpy).toHaveBeenCalledWith(
+				"deployment-url",
+				"https://preview.example.com",
+			);
+			expect(setOutputSpy).toHaveBeenCalledWith(
+				"version-id",
+				undefined,
+			);
+		});
+	});
+});

--- a/src/commandOutputParsing.ts
+++ b/src/commandOutputParsing.ts
@@ -112,6 +112,7 @@ function handleVersionsUploadOutputEntry(
 	versionsOutputEntry: OutputEntryVersionUpload,
 ) {
 	setOutput("deployment-url", versionsOutputEntry.preview_url);
+	setOutput("version-id", versionsOutputEntry.version_id);
 }
 
 /**

--- a/src/wranglerArtifactManager.ts
+++ b/src/wranglerArtifactManager.ts
@@ -45,6 +45,8 @@ export type OutputEntryVersionUpload = z.infer<typeof OutputEntryVersionUpload>;
 const OutputEntryVersionUpload = OutputEntryBase.merge(
 	z.object({
 		type: z.literal("version-upload"),
+		/** The version ID associated with this version upload */
+		version_id: z.string().optional(),
 		/** The preview URL associated with this version upload */
 		preview_url: z.string().optional(),
 	}),


### PR DESCRIPTION
## Summary

- Adds `version_id` field to the `OutputEntryVersionUpload` schema
- Sets `version-id` as a step output when running `wrangler versions upload`
- Adds `version-id` output definition to `action.yml`

Fixes #397

## Test plan

- [ ] Run `wrangler versions upload` and verify `version-id` appears in step outputs
- [ ] Verify existing `deployment-url` output still works for version uploads
- [ ] Verify no regression for `deploy` and `pages deploy` commands