### PR TITLE
Fix deployment-url output to strip suffix and ensure protocol prefix

### DIFF
--- a/.changeset/fix-deployment-url-output.md
+++ b/.changeset/fix-deployment-url-output.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Fix `deployment-url` output to strip `(custom domain)` suffix and ensure `https://` protocol prefix.

--- a/src/commandOutputParsing.test.ts
+++ b/src/commandOutputParsing.test.ts
@@ -1,0 +1,86 @@
+import * as core from "@actions/core";
+import mockfs from "mock-fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleCommandOutputParsing, sanitizeUrl } from "./commandOutputParsing";
+import { getTestConfig } from "./test/test-utils";
+
+vi.mock("./service/github", () => ({
+	createGitHubDeploymentAndJobSummary: vi.fn(),
+}));
+
+const testConfig = getTestConfig();
+
+afterEach(() => {
+	mockfs.restore();
+	vi.restoreAllMocks();
+});
+
+describe("sanitizeUrl", () => {
+	it("Returns URL unchanged when it already has https://", () => {
+		expect(sanitizeUrl("https://example.com")).toBe("https://example.com");
+	});
+
+	it("Strips text after whitespace", () => {
+		expect(sanitizeUrl("https://example.com (custom domain)")).toBe(
+			"https://example.com",
+		);
+	});
+
+	it("Prepends https:// when no protocol is present", () => {
+		expect(sanitizeUrl("example.com")).toBe("https://example.com");
+	});
+
+	it("Preserves http:// URLs without double-prefixing", () => {
+		expect(sanitizeUrl("http://example.com")).toBe("http://example.com");
+	});
+
+	it("Handles URL with both no protocol and trailing text", () => {
+		expect(sanitizeUrl("example.com (custom domain)")).toBe(
+			"https://example.com",
+		);
+	});
+});
+
+describe("handleCommandOutputParsing sanitizeUrl integration", () => {
+	it("Sanitizes pages deploy URL that has a trailing suffix", async () => {
+		const setOutputSpy = vi.spyOn(core, "setOutput");
+
+		mockfs({
+			[testConfig.WRANGLER_OUTPUT_DIR]: {
+				"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+{"version": 1, "type":"wrangler-session", "wrangler_version":"3.81.0", "command_line_args":["pages","deploy"], "log_file_path": "/here"}
+{"version": 1, "type":"pages-deploy-detailed", "pages_project": "my-project", "environment":"production", "alias":"https://alias.example.com (custom domain)", "deployment_id": "abc-123", "url":"https://my-project.pages.dev (custom domain)"}`,
+			},
+		});
+
+		await handleCommandOutputParsing(testConfig, "pages deploy", "");
+
+		expect(setOutputSpy).toHaveBeenCalledWith(
+			"deployment-url",
+			"https://my-project.pages.dev",
+		);
+		expect(setOutputSpy).toHaveBeenCalledWith(
+			"pages-deployment-alias-url",
+			"https://alias.example.com",
+		);
+	});
+
+	it("Prepends https:// to worker deploy target with no protocol", async () => {
+		const setOutputSpy = vi.spyOn(core, "setOutput");
+
+		mockfs({
+			[testConfig.WRANGLER_OUTPUT_DIR]: {
+				"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+{"version": 1, "type":"wrangler-session", "wrangler_version":"3.81.0", "command_line_args":["deploy"], "log_file_path": "/here"}
+{"version": 1, "type":"deploy", "targets": ["my-worker.example.com"]}`,
+			},
+		});
+
+		await handleCommandOutputParsing(testConfig, "deploy", "");
+
+		expect(setOutputSpy).toHaveBeenCalledWith(
+			"deployment-url",
+			"https://my-worker.example.com",
+		);
+	});
+});

--- a/src/commandOutputParsing.ts
+++ b/src/commandOutputParsing.ts
@@ -8,6 +8,22 @@ import {
 } from "./wranglerArtifactManager";
 import { createGitHubDeploymentAndJobSummary } from "./service/github";
 
+/**
+ * Sanitizes a URL by stripping any trailing text after whitespace (e.g. " (custom domain)")
+ * and prepending "https://" if no protocol is present.
+ */
+export function sanitizeUrl(url: string): string {
+	// Strip text after first whitespace
+	let sanitized = url.split(/\s/)[0];
+
+	// Prepend https:// if no protocol is present
+	if (!/^https?:\/\//.test(sanitized)) {
+		sanitized = `https://${sanitized}`;
+	}
+
+	return sanitized;
+}
+
 // fallback to trying to extract the deployment-url and pages-deployment-alias-url from stdout for wranglerVersion < 3.81.0
 function extractDeploymentUrlsFromStdout(stdOut: string): {
 	deploymentUrl?: string;
@@ -35,10 +51,13 @@ async function handlePagesDeployOutputEntry(
 	config: WranglerActionConfig,
 	pagesDeployOutputEntry: OutputEntryPagesDeployment,
 ) {
-	setOutput("deployment-url", pagesDeployOutputEntry.url);
+	setOutput("deployment-url", sanitizeUrl(pagesDeployOutputEntry.url));
 	// DEPRECATED: deployment-alias-url in favour of pages-deployment-alias, drop in next wrangler-action major version change
-	setOutput("deployment-alias-url", pagesDeployOutputEntry.alias);
-	setOutput("pages-deployment-alias-url", pagesDeployOutputEntry.alias);
+	setOutput("deployment-alias-url", sanitizeUrl(pagesDeployOutputEntry.alias));
+	setOutput(
+		"pages-deployment-alias-url",
+		sanitizeUrl(pagesDeployOutputEntry.alias),
+	);
 	setOutput("pages-deployment-id", pagesDeployOutputEntry.deployment_id);
 	setOutput("pages-environment", pagesDeployOutputEntry.environment);
 
@@ -89,7 +108,10 @@ function handleWranglerDeployOutputEntry(
 		);
 	}
 
-	setOutput("deployment-url", wranglerDeployOutputEntry.targets[0]);
+	setOutput(
+		"deployment-url",
+		sanitizeUrl(wranglerDeployOutputEntry.targets[0]),
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `sanitizeUrl()` helper that strips trailing text after whitespace (e.g. ` (custom domain)`) and prepends `https://` if no protocol is present
- Applied in `handlePagesDeployOutputEntry()` and `handleWranglerDeployOutputEntry()`

Fixes #396

## Test plan

- [ ] Verify a target like `something.other.app (custom domain)` outputs `https://something.other.app`
- [ ] Verify a target like `https://something.workers.dev` is unchanged
- [ ] Verify a target like `something.workers.dev` gets `https://` prepended