### PR TITLE
Surface wrangler error messages on command failure

### DIFF
--- a/.changeset/surface-wrangler-errors.md
+++ b/.changeset/surface-wrangler-errors.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Surface wrangler error messages in the action step output instead of showing only a generic failure message.

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -354,7 +354,18 @@ async function wranglerCommands(
 			};
 
 			// Execute the wrangler command
-			await exec(`${packageManager.exec} wrangler ${command}`, args, options);
+			try {
+				await exec(
+					`${packageManager.exec} wrangler ${command}`,
+					args,
+					options,
+				);
+			} catch (err: unknown) {
+				if (stdErr) {
+					error(config, stdErr);
+				}
+				throw err;
+			}
 
 			// Set the outputs for the command
 			setOutput("command-output", stdOut);

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -393,7 +393,18 @@ async function wranglerCommands(
 			};
 
 			// Execute the wrangler command
-			await exec(`${packageManager.exec} wrangler ${command}`, args, options);
+			try {
+				await exec(
+					`${packageManager.exec} wrangler ${command}`,
+					args,
+					options,
+				);
+			} catch (err: unknown) {
+				if (stdErr) {
+					error(config, stdErr);
+				}
+				throw err;
+			}
 
 			// Set the outputs for the command
 			setOutput("command-output", stdOut);


### PR DESCRIPTION
## Summary

- When wrangler commands fail, the actual error from stderr is now logged prominently before the exception propagates
- Users will see the real wrangler error in the GitHub Actions step output instead of just a generic "process failed with exit code 1" message

Fixes #360

## Test plan

- [ ] Run the action with a wrangler command that fails (e.g., deploy with invalid config) and verify the actual wrangler error appears in the step output
- [ ] Run the action with a successful wrangler command and verify behavior is unchanged