### PR TITLE
Warn when pages deploy runs without git checkout

### DIFF
--- a/.changeset/warn-missing-checkout.md
+++ b/.changeset/warn-missing-checkout.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": patch
+---
+
+Warn when running `pages deploy` without a prior git checkout, which could cause unintended production deployments.

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -9,9 +9,11 @@ import {
 import { getExecOutput } from "@actions/exec";
 import semverEq from "semver/functions/eq";
 import { z } from "zod";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { exec, execShell } from "./exec";
 import { PackageManager } from "./packageManagers";
-import { error, info, semverCompare } from "./utils";
+import { error, info, semverCompare, warn } from "./utils";
 import { handleCommandOutputParsing } from "./commandOutputParsing";
 import semverLt from "semver/functions/lt";
 
@@ -331,6 +333,18 @@ async function wranglerCommands(
 				for (const v of config["VARS"]) {
 					args.push(`${v}:${getEnvVar(v)}`);
 				}
+			}
+
+			if (
+				(command.startsWith("pages deploy") ||
+					command.startsWith("pages publish")) &&
+				!existsSync(resolve(config["workingDirectory"], ".git"))
+			) {
+				warn(
+					config,
+					"⚠️ No git checkout detected. Pages deploy may deploy to production instead of a preview environment. Ensure actions/checkout runs before this step.",
+					true,
+				);
 			}
 
 			// Used for saving the wrangler output

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -10,9 +10,11 @@ import { getExecOutput } from "@actions/exec";
 import semverSatisfies from "semver/functions/satisfies";
 import semverValid from "semver/functions/valid";
 import { z } from "zod";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { exec, execShell } from "./exec";
 import { PackageManager } from "./packageManagers";
-import { error, info, semverCompare } from "./utils";
+import { error, info, semverCompare, warn } from "./utils";
 import { handleCommandOutputParsing } from "./commandOutputParsing";
 import semverLt from "semver/functions/lt";
 
@@ -370,6 +372,18 @@ async function wranglerCommands(
 				for (const v of config["VARS"]) {
 					args.push(`${v}:${getEnvVar(v)}`);
 				}
+			}
+
+			if (
+				(command.startsWith("pages deploy") ||
+					command.startsWith("pages publish")) &&
+				!existsSync(resolve(config["workingDirectory"], ".git"))
+			) {
+				warn(
+					config,
+					"⚠️ No git checkout detected. Pages deploy may deploy to production instead of a preview environment. Ensure actions/checkout runs before this step.",
+					true,
+				);
 			}
 
 			// Used for saving the wrangler output


### PR DESCRIPTION
## Summary

- Adds a warning when `pages deploy` or `pages publish` is run without a `.git` directory present in the working directory
- This prevents silent production deployments when `actions/checkout` is missing or failed

Fixes #373

## Test plan

- [ ] Run `pages deploy` without `actions/checkout` and verify the warning appears
- [ ] Run `pages deploy` with `actions/checkout` and verify no warning
- [ ] Verify the deploy still proceeds (warning only, not a hard error)