### PR TITLE
Add getting started guide for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ jobs:
         packageManager: pnpm
 ```
 
+## Getting Started from Scratch
+
+If you're new to Cloudflare Workers/Pages and want step-by-step instructions to get this action working from zero (creating API tokens, setting up secrets, configuring your first project), see the [Getting Started guide](docs/getting-started.md).
+
 ## Troubleshooting
 
 ### "I just started using Workers/Wrangler and I don't know what this is!"

--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ jobs:
         packageManager: pnpm
 ```
 
+## Getting Started from Scratch
+
+If you're new to Cloudflare Workers/Pages and want step-by-step instructions to get this action working from zero (creating API tokens, setting up secrets, configuring your first project), see the [Getting Started guide](docs/getting-started.md).
+
 ## Troubleshooting
 
 ### "I just started using Workers/Wrangler and I don't know what this is!"

--- a/docs/examples/pages/.github/workflows/deploy.yml
+++ b/docs/examples/pages/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Pages Site
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    # Use "ubuntu-latest" for a GitHub-hosted runner, or replace with your
+    # self-hosted runner label (e.g. "self-hosted" or [self-hosted, linux]).
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Pages
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Replace this with your actual build step.
+      # The example below is for an mkdocs site — adapt it for
+      # your framework (Next.js, Astro, Hugo, plain HTML, etc.).
+      - name: Build site
+        run: |
+          pip install mkdocs-material
+          mkdocs build
+
+      # If your Pages project does not exist yet, uncomment the step
+      # below to create it before the first deploy.
+      # - name: Create Pages project (first-time only)
+      #   env:
+      #     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      #     CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      #   run: npx wrangler pages project create my-pages-site --production-branch main
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Change "site" to your build output directory (e.g. dist/, build/, out/)
+          # Change "my-pages-site" to your desired project name
+          command: pages deploy site --project-name=my-pages-site

--- a/docs/examples/pages/.github/workflows/deploy.yml
+++ b/docs/examples/pages/.github/workflows/deploy.yml
@@ -25,14 +25,7 @@ jobs:
           pip install mkdocs-material
           mkdocs build
 
-      # If your Pages project does not exist yet, uncomment the step
-      # below to create it before the first deploy.
-      # - name: Create Pages project (first-time only)
-      #   env:
-      #     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      #     CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      #   run: npx wrangler pages project create my-pages-site --production-branch main
-
+      # Note: "pages deploy" auto-creates the Pages project if it doesn't exist yet.
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/docs/examples/worker/.github/workflows/deploy.yml
+++ b/docs/examples/worker/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    # Use "ubuntu-latest" for a GitHub-hosted runner, or replace with your
+    # self-hosted runner label (e.g. "self-hosted" or [self-hosted, linux]).
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Workers
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/examples/worker/src/index.ts
+++ b/docs/examples/worker/src/index.ts
@@ -1,0 +1,12 @@
+export default {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+		return new Response("Hello from Cloudflare Workers!");
+	},
+} satisfies ExportedHandler<Env>;
+
+interface Env {
+	// Add your bindings here, e.g.:
+	// MY_KV: KVNamespace;
+	// MY_DURABLE_OBJECT: DurableObjectNamespace;
+	// MY_VAR: string;
+}

--- a/docs/examples/worker/wrangler.toml
+++ b/docs/examples/worker/wrangler.toml
@@ -1,0 +1,13 @@
+# See https://developers.cloudflare.com/workers/wrangler/configuration/ for full reference.
+
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+# Uncomment to set account_id here instead of passing it via the GitHub Action.
+# account_id = "your-account-id"
+
+# Uncomment to add a custom domain route.
+# [[routes]]
+# pattern = "example.com/*"
+# zone_name = "example.com"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,183 @@
+# Getting Started with `wrangler-action` from Scratch
+
+This guide walks you through every step needed to deploy a Cloudflare Workers or Pages project using this GitHub Action, starting from zero.
+
+## Prerequisites
+
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up) (free tier is fine)
+- A GitHub repository containing the project you want to deploy
+
+## Step 1: Create a Cloudflare API Token
+
+The GitHub Action authenticates with Cloudflare using an API token. You must create one with the right permissions.
+
+1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com) and click your profile icon (top right), then **My Profile**.
+2. Select **API Tokens** in the left sidebar.
+3. Click **Create Token**.
+4. Use the **Edit Cloudflare Workers** template (this covers both Workers and Pages). Alternatively, create a custom token with:
+   - **Account** > **Cloudflare Pages** > **Edit**
+   - **Account** > **Workers Scripts** > **Edit**
+   - **Account** > **Account Settings** > **Read**
+   - **Zone** > **Zone** > **Read** (if your Worker uses a custom domain)
+5. Under **Account Resources**, select the account you want to deploy to.
+6. Click **Continue to summary**, then **Create Token**.
+7. **Copy the token** — you won't be able to see it again.
+
+## Step 2: Find Your Cloudflare Account ID
+
+1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com).
+2. Select any zone (domain), or go to **Workers & Pages**.
+3. Your **Account ID** is shown on the right sidebar. Copy it.
+
+You can also find it in the URL: `https://dash.cloudflare.com/<ACCOUNT_ID>/...`
+
+## Step 3: Add Secrets to Your GitHub Repository
+
+Store your Cloudflare credentials as GitHub Actions secrets so they stay encrypted and never appear in logs.
+
+1. In your GitHub repository, go to **Settings** > **Secrets and variables** > **Actions**.
+2. Click **New repository secret** and add:
+   - **Name:** `CLOUDFLARE_API_TOKEN` — **Value:** the API token from Step 1
+   - **Name:** `CLOUDFLARE_ACCOUNT_ID` — **Value:** the account ID from Step 2
+
+## Step 4: Set Up Your Project
+
+### For Cloudflare Workers
+
+If you don't have a Workers project yet:
+
+```sh
+npx wrangler init my-worker
+cd my-worker
+```
+
+This creates a `wrangler.toml` configuration file and a basic Worker. Push it to your GitHub repo.
+
+Your `wrangler.toml` should include at minimum:
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+```
+
+> **Note:** You do _not_ need to set `account_id` in `wrangler.toml` if you pass `accountId` to the GitHub Action (recommended — keeps credentials out of your repo).
+
+### For Cloudflare Pages
+
+If you have a static site (e.g. built with mkdocs, Next.js, Astro, etc.):
+
+1. **You do not need to create a Pages project in the Cloudflare dashboard first.** The `wrangler pages deploy` command will create it for you on the first run.
+2. Make sure your build step produces a directory of static files (e.g. `site/`, `dist/`, `build/`).
+
+## Step 5: Create the GitHub Actions Workflow
+
+Create a file at `.github/workflows/deploy.yml` in your repository.
+
+### Workers Example
+
+```yaml
+name: Deploy Worker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+### Pages Example (e.g. for an mkdocs site)
+
+```yaml
+name: Deploy Pages Site
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build site
+        run: |
+          pip install mkdocs-material
+          mkdocs build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=my-docs-site
+```
+
+Replace `site` with your build output directory and `my-docs-site` with whatever you want your Pages project to be named. If the project doesn't exist yet, Wrangler will create it automatically.
+
+## Step 6: Push and Verify
+
+1. Commit and push the workflow file to your `main` branch.
+2. Go to the **Actions** tab in your GitHub repository.
+3. You should see the workflow running. Click into it to see logs.
+4. Once successful, your site/worker will be live at:
+   - **Workers:** `https://my-worker.<your-subdomain>.workers.dev`
+   - **Pages:** `https://my-docs-site.pages.dev`
+
+## Common Issues
+
+### "No account id found, quitting..."
+
+Either add `accountId` to the action inputs (recommended) or set `account_id` in your `wrangler.toml`:
+
+```yaml
+with:
+  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+### "Authentication error"
+
+Make sure your API token has the correct permissions (see Step 1) and that the `CLOUDFLARE_API_TOKEN` secret is set correctly in your repository settings.
+
+### Pages project not found
+
+If using `pages deploy`, Wrangler will create the project automatically on the first deploy. Make sure:
+- You're specifying a `--project-name`
+- Your API token has Pages edit permissions
+- You've set the `accountId`
+
+### Preview deployments
+
+Pushes to non-production branches automatically create preview deployments. You can access them at `https://<branch>.<project>.pages.dev`. To deploy only on `main`, restrict the workflow trigger:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+```
+
+## Next Steps
+
+- See the [README](../README.md) for the full list of action inputs, outputs, and advanced usage (secrets, pre/post commands, custom wrangler versions, etc.)
+- See the [Cloudflare Workers docs](https://developers.cloudflare.com/workers/) and [Pages docs](https://developers.cloudflare.com/pages/) for platform-specific guidance
+- See [Wrangler documentation](https://developers.cloudflare.com/workers/wrangler/) for CLI reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,6 +142,33 @@ jobs:
 
 Replace `site` with your build output directory and `my-docs-site` with whatever you want your Pages project to be named. If the project doesn't exist yet, Wrangler will attempt to create it automatically — but see Step 4 if you need to create it explicitly.
 
+### GitHub-Hosted vs Self-Hosted Runners
+
+The examples above use `runs-on: ubuntu-latest`, which runs on a [GitHub-hosted runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners). These are managed by GitHub, come with Node.js and common tools pre-installed, and work out of the box with no setup.
+
+If your organization uses [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners), replace the `runs-on` value with your runner's label:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: self-hosted          # or a custom label like [self-hosted, linux]
+```
+
+Key differences to be aware of:
+
+| | GitHub-Hosted | Self-Hosted |
+|---|---|---|
+| **Setup** | None — managed by GitHub | You provision and maintain the runner |
+| **Environment** | Clean VM each run; Node.js pre-installed | Persistent environment; you must ensure Node.js is available |
+| **Network** | Public internet access | Can access private networks (useful for internal APIs) |
+| **Cost** | Free tier minutes included; paid beyond that | You pay for your own infrastructure |
+| **Security** | Isolated per job | Shared across jobs unless you configure otherwise — avoid on public repos |
+
+When using self-hosted runners, make sure:
+- **Node.js** is installed (the action requires it).
+- The runner can reach the **Cloudflare API** (`api.cloudflare.com`) and **npm registry** (`registry.npmjs.org`) to install and run Wrangler.
+- You trust all workflows that will run on the runner, especially if the repository is public.
+
 ## Step 6: Push and Verify
 
 1. Commit and push the workflow file to your `main` branch.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,11 +14,13 @@ The GitHub Action authenticates with Cloudflare using an API token. You must cre
 1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com) and click your profile icon (top right), then **My Profile**.
 2. Select **API Tokens** in the left sidebar.
 3. Click **Create Token**.
-4. Use the **Edit Cloudflare Workers** template (this covers both Workers and Pages). Alternatively, create a custom token with:
-   - **Account** > **Cloudflare Pages** > **Edit**
-   - **Account** > **Workers Scripts** > **Edit**
+4. Use the **Edit Cloudflare Workers** template (this covers both Workers and Pages). Alternatively, create a custom token with only the permissions you need:
+   - **Account** > **Cloudflare Pages** > **Edit** (if deploying a Pages project)
+   - **Account** > **Workers Scripts** > **Edit** (if deploying a Worker)
    - **Account** > **Account Settings** > **Read**
    - **Zone** > **Zone** > **Read** (if your Worker uses a custom domain)
+
+   > You do not need both Pages and Workers permissions — include only what applies to your project.
 5. Under **Account Resources**, select the account you want to deploy to.
 6. Click **Continue to summary**, then **Create Token**.
 7. **Copy the token** — you won't be able to see it again.
@@ -52,6 +54,8 @@ cd my-worker
 ```
 
 This creates a `wrangler.toml` configuration file and a basic Worker. Push it to your GitHub repo.
+
+The `wrangler.toml` file must be in the root of your repository (or in the directory specified by the `workingDirectory` input if you use one). The action looks for it automatically — you do not need to pass it as a parameter.
 
 Your `wrangler.toml` should include at minimum:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,8 @@ The GitHub Action authenticates with Cloudflare using an API token. You must cre
    - **Account** > **Cloudflare Pages** > **Edit** (if deploying a Pages project)
    - **Account** > **Workers Scripts** > **Edit** (if deploying a Worker)
    - **Account** > **Account Settings** > **Read**
-   - **Zone** > **Zone** > **Read** (if your Worker uses a custom domain)
+   - **Zone** > **Zone** > **Read** (if your project uses a custom domain or you need zone-level access)
+   - **Zone** > **Zone Resources** > **Read** (required for zone-scoped operations)
 
    > You do not need both Pages and Workers permissions — include only what applies to your project.
 5. Under **Account Resources**, select the account you want to deploy to.
@@ -28,7 +29,7 @@ The GitHub Action authenticates with Cloudflare using an API token. You must cre
 ## Step 2: Find Your Cloudflare Account ID
 
 1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com).
-2. Select any zone (domain), or go to **Workers & Pages**.
+2. Select any zone (domain), or go to **Workers & Pages** under the **Compute** section.
 3. Your **Account ID** is shown on the right sidebar. Copy it.
 
 You can also find it in the URL: `https://dash.cloudflare.com/<ACCOUNT_ID>/...`
@@ -71,8 +72,12 @@ compatibility_date = "2024-01-01"
 
 If you have a static site (e.g. built with mkdocs, Next.js, Astro, etc.):
 
-1. **You do not need to create a Pages project in the Cloudflare dashboard first.** The `wrangler pages deploy` command will create it for you on the first run.
-2. Make sure your build step produces a directory of static files (e.g. `site/`, `dist/`, `build/`).
+1. Make sure your build step produces a directory of static files (e.g. `site/`, `dist/`, `build/`).
+2. If your Pages project does not exist yet, you can either create it in the Cloudflare dashboard or let `wrangler pages deploy` attempt to create it on the first run. However, automatic creation may not work in all cases. If you run into issues, create the project explicitly before deploying:
+
+   ```sh
+   npx wrangler pages project create my-docs-site --production-branch main
+   ```
 
 ## Step 5: Create the GitHub Actions Workflow
 
@@ -135,7 +140,7 @@ jobs:
           command: pages deploy site --project-name=my-docs-site
 ```
 
-Replace `site` with your build output directory and `my-docs-site` with whatever you want your Pages project to be named. If the project doesn't exist yet, Wrangler will create it automatically.
+Replace `site` with your build output directory and `my-docs-site` with whatever you want your Pages project to be named. If the project doesn't exist yet, Wrangler will attempt to create it automatically — but see Step 4 if you need to create it explicitly.
 
 ## Step 6: Push and Verify
 
@@ -164,7 +169,13 @@ Make sure your API token has the correct permissions (see Step 1) and that the `
 
 ### Pages project not found
 
-If using `pages deploy`, Wrangler will create the project automatically on the first deploy. Make sure:
+If using `pages deploy`, Wrangler will attempt to create the project on the first deploy, but this may fail depending on your token permissions. If it does, create the project explicitly first:
+
+```sh
+npx wrangler pages project create my-docs-site --production-branch main
+```
+
+Also make sure:
 - You're specifying a `--project-name`
 - Your API token has Pages edit permissions
 - You've set the `accountId`


### PR DESCRIPTION
## Summary
- Adds `docs/getting-started.md` with step-by-step instructions for setting up the action from scratch
- Covers: API token creation, finding account ID, adding GitHub secrets, project setup (Workers & Pages), workflow configuration, common issues
- Adds a link from the README to the new guide
- Addresses review feedback: adds Zone Resources permission, clarifies dashboard navigation, fixes Pages auto-creation claims with explicit fallback
- Adds GitHub-hosted vs self-hosted runners section with comparison table and requirements
- Adds stubbed example projects under `docs/examples/` for both Pages and Workers deployments

Closes #414

## Test plan
- [ ] Review guide for accuracy against current Cloudflare dashboard flow
- [ ] Verify the Pages example workflow works for a new project (auto-creation and explicit creation)
- [ ] Verify the Workers example workflow works with a fresh `wrangler init` project
- [ ] Confirm Zone Resources permission is needed for token setup
- [ ] Test example stubs can be copied into a new repo and run successfully