### PR TITLE
Support version ranges and tags in wranglerVersion input

### DIFF
--- a/.changeset/support-version-ranges.md
+++ b/.changeset/support-version-ranges.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Support version ranges and tags in `wranglerVersion` input. You can now set `wranglerVersion` to values like `4`, `^4.0.0`, `4.x`, or `latest` instead of only exact versions like `4.81.0`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
 
 ## Configuration
 
-If you need to install a specific version of Wrangler to use for deployment, you can also pass the input `wranglerVersion` to install a specific version of Wrangler from NPM. This should be a [SemVer](https://semver.org/)-style version number, such as `2.20.0`:
+You can pass `wranglerVersion` to install a specific version of Wrangler from NPM. This accepts any version format NPM understands: an exact version like `4.81.0`, a major version like `4`, a range like `^4.0.0` or `4.x`, or `latest`.
 
 ```yaml
 jobs:
@@ -61,8 +61,10 @@ jobs:
       uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        wranglerVersion: "2.20.0"
+        wranglerVersion: "4"
 ```
+
+If you omit `wranglerVersion` and Wrangler is already installed in your environment, the action uses the existing installation. If Wrangler is not installed, the action installs a default version.
 
 Optionally, you can also pass a `workingDirectory` key to the action. This will allow you to specify a subdirectory of the repo to run the Wrangler command from.
 

--- a/src/wranglerAction.test.ts
+++ b/src/wranglerAction.test.ts
@@ -1,8 +1,58 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import { describe, expect, it, vi } from "vitest";
-import { installWrangler, uploadSecrets } from "./wranglerAction";
+import {
+	installWrangler,
+	isExactSemver,
+	main,
+	parseWranglerVersion,
+	uploadSecrets,
+} from "./wranglerAction";
 import { getTestConfig } from "./test/test-utils";
+
+describe("parseWranglerVersion", () => {
+	it("parses version from verbose wrangler output", () => {
+		expect(
+			parseWranglerVersion(` ⛅️ wrangler 3.48.0 (update available 3.53.1)`),
+		).toBe("3.48.0");
+	});
+
+	it("parses version from bare version output", () => {
+		expect(parseWranglerVersion("4.18.1\n")).toBe("4.18.1");
+	});
+
+	it("returns empty string for unparseable output", () => {
+		expect(parseWranglerVersion("something unexpected")).toBe("");
+	});
+
+	it("parses prerelease version", () => {
+		expect(parseWranglerVersion(` ⛅️ wrangler 4.0.0-beta.1`)).toBe(
+			"4.0.0-beta.1",
+		);
+	});
+
+	it("parses bare prerelease version", () => {
+		expect(parseWranglerVersion("4.0.0-rc.0\n")).toBe("4.0.0-rc.0");
+	});
+});
+
+describe("isExactSemver", () => {
+	it.each([
+		["4.81.0", true],
+		["3.48.0", true],
+		["2.20.0", true],
+		["4.0.0-beta.1", true],
+		["4", false],
+		["4.x", false],
+		["4.*", false],
+		["^4.0.0", false],
+		["~4.0.0", false],
+		["latest", false],
+		["", false],
+	])("isExactSemver(%s) === %s", (input, expected) => {
+		expect(isExactSemver(input)).toBe(expected);
+	});
+});
 
 describe("installWrangler", () => {
 	const testPackageManager = {
@@ -30,10 +80,14 @@ describe("installWrangler", () => {
 			};
 		});
 		const infoSpy = vi.spyOn(core, "info");
-		await installWrangler(testConfig, testPackageManager);
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
 		expect(infoSpy).toBeCalledWith(
 			"✅ No wrangler version specified, using pre-installed wrangler version 3.48.0",
 		);
+		expect(resolvedVersion).toBe("3.48.0");
 	});
 
 	it("Does nothing if the wrangler version specified is the same as the one installed", async () => {
@@ -51,9 +105,14 @@ describe("installWrangler", () => {
 			};
 		});
 		const infoSpy = vi.spyOn(core, "info");
-		await installWrangler(testConfig, testPackageManager);
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
 		expect(infoSpy).toBeCalledWith("✅ Using Wrangler 3.48.0");
+		expect(resolvedVersion).toBe("3.48.0");
 	});
+
 	it("Should install wrangler if the version specified is not already available", async () => {
 		const testConfig = getTestConfig({
 			config: {
@@ -61,19 +120,208 @@ describe("installWrangler", () => {
 				didUserProvideWranglerVersion: true,
 			},
 		});
+		let callCount = 0;
 		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				// Pre-install check: different version installed
+				return {
+					exitCode: 0,
+					stderr: "",
+					stdout: ` ⛅️ wrangler 3.20.0 (update available 3.53.1)`,
+				};
+			}
+			// Post-install check: correct version now installed
 			return {
 				exitCode: 0,
 				stderr: "",
-				stdout: ` ⛅️ wrangler 3.20.0 (update available 3.53.1)`,
+				stdout: ` ⛅️ wrangler 3.48.0`,
 			};
 		});
 		vi.spyOn(exec, "exec").mockImplementation(async () => {
 			return 0;
 		});
 		const infoSpy = vi.spyOn(core, "info");
-		await installWrangler(testConfig, testPackageManager);
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
 		expect(infoSpy).toBeCalledWith("✅ Wrangler installed");
+		expect(resolvedVersion).toBe("3.48.0");
+	});
+
+	it("Should install and resolve version when a range like '4' is specified", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "4",
+				didUserProvideWranglerVersion: true,
+			},
+		});
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				// Pre-install check: older version installed
+				return {
+					exitCode: 0,
+					stderr: "",
+					stdout: ` ⛅️ wrangler 3.90.0`,
+				};
+			}
+			// Post-install check: v4 now installed
+			return {
+				exitCode: 0,
+				stderr: "",
+				stdout: `4.18.1`,
+			};
+		});
+		vi.spyOn(exec, "exec").mockImplementation(async (cmd, args) => {
+			if (cmd === "npm i") expect(args).toStrictEqual(["wrangler@4"]);
+			return 0;
+		});
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
+		expect(resolvedVersion).toBe("4.18.1");
+	});
+
+	it("Should install and resolve version when 'latest' is specified", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "latest",
+				didUserProvideWranglerVersion: true,
+			},
+		});
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				// Pre-install: no wrangler found
+				throw new Error("command not found");
+			}
+			// Post-install check
+			return {
+				exitCode: 0,
+				stderr: "",
+				stdout: `4.20.0`,
+			};
+		});
+		vi.spyOn(exec, "exec").mockImplementation(async (cmd, args) => {
+			if (cmd === "npm i") {
+				expect(args).toStrictEqual(["wrangler@latest"]);
+			}
+			return 0;
+		});
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
+		expect(resolvedVersion).toBe("4.20.0");
+	});
+
+	it("Throws if version cannot be resolved after install", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "4",
+				didUserProvideWranglerVersion: true,
+			},
+		});
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				throw new Error("not found");
+			}
+			// Post-install: unparseable output
+			return { exitCode: 0, stderr: "", stdout: "garbage output" };
+		});
+		vi.spyOn(exec, "exec").mockResolvedValue(0);
+		await expect(
+			installWrangler(testConfig, testPackageManager),
+		).rejects.toThrowError(
+			"Failed to determine installed Wrangler version after installing wrangler@4",
+		);
+	});
+
+	it("Falls back to raw version when post-install resolution fails for exact semver", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "3.48.0",
+				didUserProvideWranglerVersion: true,
+			},
+		});
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				throw new Error("not found");
+			}
+			throw new Error("wrangler --version failed");
+		});
+		vi.spyOn(exec, "exec").mockResolvedValue(0);
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
+		expect(resolvedVersion).toBe("3.48.0");
+	});
+
+	it("Skips reinstall when range is satisfied by pre-installed version", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "4",
+				didUserProvideWranglerVersion: true,
+			},
+		});
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			return {
+				exitCode: 0,
+				stderr: "",
+				stdout: `4.18.1`,
+			};
+		});
+		const execSpy = vi.spyOn(exec, "exec");
+		const infoSpy = vi.spyOn(core, "info");
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
+		expect(infoSpy).toBeCalledWith("✅ Using Wrangler 4.18.1");
+		expect(resolvedVersion).toBe("4.18.1");
+		expect(execSpy).not.toHaveBeenCalled();
+	});
+
+	it("Reinstalls when range is NOT satisfied by pre-installed version", async () => {
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "4",
+				didUserProvideWranglerVersion: true,
+			},
+		});
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				// Pre-installed is v3, doesn't satisfy "4"
+				return {
+					exitCode: 0,
+					stderr: "",
+					stdout: ` ⛅️ wrangler 3.90.0`,
+				};
+			}
+			return {
+				exitCode: 0,
+				stderr: "",
+				stdout: `4.18.1`,
+			};
+		});
+		vi.spyOn(exec, "exec").mockResolvedValue(0);
+		const resolvedVersion = await installWrangler(
+			testConfig,
+			testPackageManager,
+		);
+		expect(resolvedVersion).toBe("4.18.1");
 	});
 });
 
@@ -161,5 +409,76 @@ describe("uploadSecrets", () => {
 		await uploadSecrets(testConfig, testPackageManager);
 		expect(startGroup).toBeCalledWith("🔑 Uploading secrets...");
 		expect(endGroup).toHaveBeenCalledOnce();
+	});
+});
+
+describe("main", () => {
+	const testPackageManager = {
+		install: "npm i",
+		exec: "npx",
+		execNoInstall: "npx --no-install",
+	};
+
+	it("Completes with wranglerVersion '4' and secrets without Invalid Version error", async () => {
+		vi.stubEnv("MY_SECRET", "secret_value");
+
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "4",
+				didUserProvideWranglerVersion: true,
+				secrets: ["MY_SECRET"],
+				COMMANDS: ["deploy"],
+			},
+		});
+
+		vi.spyOn(core, "getMultilineInput").mockReturnValue([]);
+
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				throw new Error("command not found");
+			}
+			return { exitCode: 0, stderr: "", stdout: "4.18.1" };
+		});
+
+		vi.spyOn(exec, "exec").mockResolvedValue(0);
+		const setFailedSpy = vi.spyOn(core, "setFailed");
+
+		await main(testConfig, testPackageManager);
+
+		expect(setFailedSpy).not.toHaveBeenCalled();
+	});
+
+	it("Completes with wranglerVersion 'latest' and secrets without Invalid Version error", async () => {
+		vi.stubEnv("MY_SECRET", "secret_value");
+
+		const testConfig = getTestConfig({
+			config: {
+				WRANGLER_VERSION: "latest",
+				didUserProvideWranglerVersion: true,
+				secrets: ["MY_SECRET"],
+				COMMANDS: ["deploy"],
+			},
+		});
+
+		vi.spyOn(core, "getMultilineInput").mockReturnValue([]);
+
+		let callCount = 0;
+		vi.spyOn(exec, "getExecOutput").mockImplementation(async () => {
+			callCount++;
+			if (callCount === 1) {
+				throw new Error("command not found");
+			}
+			return { exitCode: 0, stderr: "", stdout: "4.20.0" };
+		});
+
+		vi.spyOn(exec, "exec").mockResolvedValue(0);
+
+		const setFailedSpy = vi.spyOn(core, "setFailed");
+
+		await main(testConfig, testPackageManager);
+
+		expect(setFailedSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -7,7 +7,8 @@ import {
 	setOutput,
 } from "@actions/core";
 import { getExecOutput } from "@actions/exec";
-import semverEq from "semver/functions/eq";
+import semverSatisfies from "semver/functions/satisfies";
+import semverValid from "semver/functions/valid";
 import { z } from "zod";
 import { exec, execShell } from "./exec";
 import { PackageManager } from "./packageManagers";
@@ -51,32 +52,60 @@ async function main(
 	try {
 		wranglerActionConfig.parse(config);
 		authenticationSetup(config);
-		await installWrangler(config, packageManager);
+		const resolvedVersion = await installWrangler(config, packageManager);
+		const resolvedConfig = { ...config, WRANGLER_VERSION: resolvedVersion };
+
 		await execCommands(
-			config,
+			resolvedConfig,
 			packageManager,
 			getMultilineInput("preCommands"),
 			"pre",
 		);
-		await uploadSecrets(config, packageManager);
-		await wranglerCommands(config, packageManager);
+		await uploadSecrets(resolvedConfig, packageManager);
+		await wranglerCommands(resolvedConfig, packageManager);
 		await execCommands(
-			config,
+			resolvedConfig,
 			packageManager,
 			getMultilineInput("postCommands"),
 			"post",
 		);
-		info(config, "🏁 Wrangler Action completed", true);
+		info(resolvedConfig, "🏁 Wrangler Action completed", true);
 	} catch (err: unknown) {
 		err instanceof Error && error(config, err.message);
 		setFailed("🚨 Action failed");
 	}
 }
 
+function parseWranglerVersion(stdout: string): string {
+	const match =
+		stdout.match(/wrangler (\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)/) ??
+		stdout.match(/^(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)/m);
+	return match ? match[1] : "";
+}
+
+function isExactSemver(version: string): boolean {
+	return semverValid(version) !== null;
+}
+
+async function resolveInstalledVersion(
+	config: WranglerActionConfig,
+	packageManager: PackageManager,
+): Promise<string> {
+	const { stdout } = await getExecOutput(
+		packageManager.execNoInstall,
+		["wrangler", "--version"],
+		{
+			cwd: config["workingDirectory"],
+			silent: config.QUIET_MODE,
+		},
+	);
+	return parseWranglerVersion(stdout);
+}
+
 async function installWrangler(
 	config: WranglerActionConfig,
 	packageManager: PackageManager,
-) {
+): Promise<string> {
 	if (config["WRANGLER_VERSION"].startsWith("1")) {
 		throw new Error(
 			`Wrangler v1 is no longer supported by this action. Please use major version 2 or greater`,
@@ -85,33 +114,25 @@ async function installWrangler(
 
 	startGroup(config, "🔍 Checking for existing Wrangler installation");
 	let installedVersion = "";
-	let installedVersionSatisfiesRequirement = false;
+	let versionSatisfied = false;
 	try {
-		const { stdout } = await getExecOutput(
-			// We want to simply invoke wrangler to check if it's installed, but don't want to auto-install it at this stage
-			packageManager.execNoInstall,
-			["wrangler", "--version"],
-			{
-				cwd: config["workingDirectory"],
-				silent: config.QUIET_MODE,
-			},
-		);
+		installedVersion = await resolveInstalledVersion(config, packageManager);
 
-		// There are two possible outputs from `wrangler --version`:
-		// ` ⛅️ wrangler 3.48.0 (update available 3.53.1)`
-		// and
-		// `3.48.0`
-		const versionMatch =
-			stdout.match(/wrangler (\d+\.\d+\.\d+)/) ??
-			stdout.match(/^(\d+\.\d+\.\d+)/m);
-		if (versionMatch) {
-			installedVersion = versionMatch[1];
-		}
-		if (config.didUserProvideWranglerVersion) {
-			installedVersionSatisfiesRequirement = semverEq(
-				installedVersion,
-				config["WRANGLER_VERSION"],
-			);
+		if (config.didUserProvideWranglerVersion && installedVersion) {
+			if (isExactSemver(config["WRANGLER_VERSION"])) {
+				versionSatisfied = installedVersion === config["WRANGLER_VERSION"];
+			} else {
+				// semverSatisfies handles ranges like "4", "^4.0.0", "4.x".
+				// Returns false for dist-tags like "latest", falling through to reinstall.
+				try {
+					versionSatisfied = semverSatisfies(
+						installedVersion,
+						config["WRANGLER_VERSION"],
+					);
+				} catch {
+					versionSatisfied = false;
+				}
+			}
 		}
 		if (!config.didUserProvideWranglerVersion && installedVersion) {
 			info(
@@ -120,15 +141,12 @@ async function installWrangler(
 				true,
 			);
 			endGroup(config);
-			return;
+			return installedVersion;
 		}
-		if (
-			config.didUserProvideWranglerVersion &&
-			installedVersionSatisfiesRequirement
-		) {
+		if (config.didUserProvideWranglerVersion && versionSatisfied) {
 			info(config, `✅ Using Wrangler ${installedVersion}`, true);
 			endGroup(config);
-			return;
+			return installedVersion;
 		}
 		info(
 			config,
@@ -161,6 +179,27 @@ async function installWrangler(
 	} finally {
 		endGroup(config);
 	}
+
+	let resolvedVersion = "";
+	try {
+		resolvedVersion = await resolveInstalledVersion(config, packageManager);
+	} catch (err) {
+		debug(`Error resolving installed Wrangler version: ${err}`);
+	}
+
+	if (resolvedVersion) {
+		return resolvedVersion;
+	}
+
+	// Fall back to the raw version string if it's already valid semver.
+	// This preserves pre-existing behavior for exact version inputs.
+	if (isExactSemver(config["WRANGLER_VERSION"])) {
+		return config["WRANGLER_VERSION"];
+	}
+
+	throw new Error(
+		`Failed to determine installed Wrangler version after installing wrangler@${config["WRANGLER_VERSION"]}`,
+	);
 }
 
 function authenticationSetup(config: WranglerActionConfig) {
@@ -373,7 +412,9 @@ export {
 	execCommands,
 	info,
 	installWrangler,
+	isExactSemver,
 	main,
+	parseWranglerVersion,
 	uploadSecrets,
 	wranglerCommands,
 };


### PR DESCRIPTION
The wranglerVersion input only accepted exact versions like '4.81.0'. Setting it to a major version like '4', a range like '^4.0.0', or a tag like 'latest' crashed with 'Invalid Version' during secret uploads. npm installed the right version fine, but subsequent version comparisons failed because they expected exact X.Y.Z format.

After installing wrangler, the action now runs wrangler --version to get the concrete installed version and uses that for all version comparisons. If version detection fails and the user gave an exact version, the action falls back to using it directly, preserving existing behavior.

Pre-installed versions that satisfy a range skip reinstallation.

Fixes #390
Relates to #366
Relates to #379