### PR TITLE
docs: add missing install and build steps to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v6
-      - name: Deploy app
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
The quick start example was missing npm ci and npm run build steps, which are required before deploying with wrangler-action.

Fixes #408