### PR TITLE
ci(deploy): top-level contents: read on the self-testing workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   wrangler_action_self_testing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `deploy.yml` — the workflow that runs the action against test-fixture Workers on PR. All wrangler deploys/deletes use `secrets.CLOUDFLARE_API_TOKEN` and `secrets.CLOUDFLARE_ACCOUNT_ID`, so the GitHub token only needs read access to the checkout.

Lines up with the top-level permissions blocks already in `release.yml` and `semgrep.yml`. YAML validated locally.