### PR TITLE
ci(release): update build and tag action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
 
       - name: Push dist-tags
         if: steps.changesets.outputs.published == 'true'
-        uses: JasonEtco/build-and-tag-action@v2
+        uses: Daniel-H123/build-and-tag-action@v3
         with:
           tag_name: v${{ fromJSON(steps.changesets.outputs.publishedPackages)[0].version }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          github_token: ${{ github.token }}


### PR DESCRIPTION
JasonEtco/build-and-tag-action@v2, that is used for building the action and updating the version tags, still runs on the Node 20 runtime and outdated packages and is no longer actively maintained.

Since the package hasn’t been updated for a few years, I've created a fork where I’ve modernized it.

See: https://github.com/Daniel-H123/build-and-tag-action