### PR TITLE
feat: add Workers Previews support

### DIFF
--- a/.changeset/workers-previews.md
+++ b/.changeset/workers-previews.md
@@ -1,0 +1,5 @@
+---
+"wrangler-action": minor
+---
+
+Add support for Workers Previews, including Preview artifact parsing, Preview outputs, GitHub Deployments, and job summaries for `wrangler preview`.

--- a/README.md
+++ b/README.md
@@ -272,33 +272,17 @@ jobs:
 
 ### Deploy a Workers Preview
 
-Workers Previews let you test non-production branches in isolated environments with their own URLs, variables, secrets, and bindings. Use `wrangler preview` instead of `wrangler deploy` for any branch that isn't your production branch.
+Workers Previews let you test non-production branches with their own URLs, variables, secrets, and bindings. Use `command: preview` instead of the default `deploy` command.
 
-The recommended setup uses two workflows: one for production deploys on `main`, and one for preview deploys on all other branches:
+Before using this workflow, add your Cloudflare credentials as GitHub Actions secrets:
 
-**Production deploy** (`.github/workflows/deploy.yml`):
-
-```yaml
-name: Deploy
-
-on:
-  push:
-    branches:
-      - main
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Deploy to production
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```sh
+gh auth login
+gh secret set CLOUDFLARE_API_TOKEN
+gh secret set CLOUDFLARE_ACCOUNT_ID
 ```
 
-**Preview deploy** (`.github/workflows/preview.yml`):
+GitHub Actions provides `${{ secrets.GITHUB_TOKEN }}` automatically. You do not need to create it yourself.
 
 ```yaml
 name: Preview
@@ -309,12 +293,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
   deployments: write
-
-concurrency:
-  group: preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   preview:
@@ -330,56 +309,20 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: preview
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Comment preview URL on PR
-        uses: actions/github-script@v7
-        env:
-          PREVIEW_URL: ${{ steps.preview.outputs.preview-url }}
-        with:
-          script: |
-            const marker = '<!-- cloudflare-worker-preview -->';
-            const body = `${marker}\n### Cloudflare Workers Preview\n- Preview: ${process.env.PREVIEW_URL}`;
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
-            const existing = comments.find(c => c.user?.type === 'Bot' && c.body?.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
-
-  cleanup:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Delete preview
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: preview delete --skip-confirmation
 ```
 
 The action sets the following outputs for preview commands:
 
-| Output                  | Description                                               |
-| ----------------------- | --------------------------------------------------------- |
-| `deployment-url`        | The stable preview URL (same as `preview-url`)            |
-| `preview-url`           | The stable preview URL for the branch                     |
-| `preview-deployment-url`| The immutable URL for this specific deployment            |
-| `preview-name`          | The preview name (defaults to the git branch name)        |
-| `preview-id`            | The preview resource ID                                   |
-| `preview-deployment-id` | The deployment ID within the preview                      |
+| Output                   | Description                                        |
+| ------------------------ | -------------------------------------------------- |
+| `deployment-url`         | The stable preview URL (same as `preview-url`)     |
+| `preview-url`            | The stable Preview URL for the branch              |
+| `preview-deployment-url` | The immutable URL for this specific deployment     |
+| `preview-name`           | The Preview name (defaults to the git branch name) |
+| `preview-id`             | The Preview resource ID                            |
+| `preview-deployment-id`  | The deployment ID within the Preview               |
 
-When `gitHubToken` is provided, the action creates a GitHub Deployment with the preview URL linked as the environment URL. The workflow above also:
-
-- **Comments the preview URL on the PR** so reviewers can find it immediately
-- **Cleans up previews** when the PR is closed or merged
-- **Cancels in-progress deploys** for the same PR using concurrency groups
-
-For more on Workers Previews, see the [Workers Previews documentation](https://developers.cloudflare.com/workers/previews/).
+When `gitHubToken` is provided, the action creates a GitHub Deployment with the Preview URL linked as the environment URL and writes a job summary. For the plain `wrangler preview --json` workflow, PR comments, and cleanup examples, refer to [Automate Previews](https://developers.cloudflare.com/workers/previews/automate-previews/).
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,117 @@ jobs:
           command: versions upload
 ```
 
+### Deploy a Workers Preview
+
+Workers Previews let you test non-production branches in isolated environments with their own URLs, variables, secrets, and bindings. Use `wrangler preview` instead of `wrangler deploy` for any branch that isn't your production branch.
+
+The recommended setup uses two workflows: one for production deploys on `main`, and one for preview deploys on all other branches:
+
+**Production deploy** (`.github/workflows/deploy.yml`):
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Deploy to production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+**Preview deploy** (`.github/workflows/preview.yml`):
+
+```yaml
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Deploy preview
+        id: preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: preview
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview-url }}
+        with:
+          script: |
+            const marker = '<!-- cloudflare-worker-preview -->';
+            const body = `${marker}\n### Cloudflare Workers Preview\n- Preview: ${process.env.PREVIEW_URL}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find(c => c.user?.type === 'Bot' && c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Delete preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: preview delete --skip-confirmation
+```
+
+The action sets the following outputs for preview commands:
+
+| Output                  | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `deployment-url`        | The stable preview URL (same as `preview-url`)            |
+| `preview-url`           | The stable preview URL for the branch                     |
+| `preview-deployment-url`| The immutable URL for this specific deployment            |
+| `preview-name`          | The preview name (defaults to the git branch name)        |
+| `preview-id`            | The preview resource ID                                   |
+| `preview-deployment-id` | The deployment ID within the preview                      |
+
+When `gitHubToken` is provided, the action creates a GitHub Deployment with the preview URL linked as the environment URL. The workflow above also:
+
+- **Comments the preview URL on the PR** so reviewers can find it immediately
+- **Cleans up previews** when the PR is closed or merged
+- **Cancels in-progress deploys** for the same PR using concurrency groups
+
+For more on Workers Previews, see the [Workers Previews documentation](https://developers.cloudflare.com/workers/previews/).
+
 ## Advanced Usage
 
 ### Setting A Worker Secret for A Specific Environment

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Deploy preview
         id: preview
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -284,6 +284,26 @@ gh secret set CLOUDFLARE_ACCOUNT_ID
 
 GitHub Actions provides `${{ secrets.GITHUB_TOKEN }}` automatically. You do not need to create it yourself.
 
+If you prefer plain YAML without this action, run Wrangler directly:
+
+```yaml
+name: Preview
+
+on: [pull_request]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: npx wrangler preview --json
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+Add install or build steps before `npx wrangler preview --json` if your Worker needs them. To use `wrangler-action` instead, use this workflow:
+
 ```yaml
 name: Preview
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ The action sets the following outputs for preview commands:
 | `preview-id`             | The Preview resource ID                            |
 | `preview-deployment-id`  | The deployment ID within the Preview               |
 
-When `gitHubToken` is provided, the action creates a GitHub Deployment with the Preview URL linked as the environment URL and writes a job summary. For the plain `wrangler preview --json` workflow, PR comments, and cleanup examples, refer to [Automate Previews](https://developers.cloudflare.com/workers/previews/automate-previews/).
+When `gitHubToken` is provided, the action creates a GitHub Deployment with the Preview URL linked as the environment URL and writes a job summary. For the plain `wrangler preview --json` workflow, PR comments, and cleanup examples, refer to [Automation examples](https://developers.cloudflare.com/workers/previews/automation-examples/).
 
 ## Advanced Usage
 

--- a/action.yml
+++ b/action.yml
@@ -60,3 +60,13 @@ outputs:
     description: "If the command was a Pages deployment, this will be the ID of the deployment - needs wrangler >= 3.81.0"
   pages-environment:
     description: "If the command was a Pages deployment, this will be the environment of the deployment - needs wrangler >= 3.81.0"
+  preview-url:
+    description: "If the command was a Workers Preview deployment, this will be the stable Preview URL for the branch"
+  preview-deployment-url:
+    description: "If the command was a Workers Preview deployment, this will be the immutable deployment URL"
+  preview-name:
+    description: "If the command was a Workers Preview deployment, this will be the Preview name (typically the branch name)"
+  preview-id:
+    description: "If the command was a Workers Preview deployment, this will be the Preview resource ID"
+  preview-deployment-id:
+    description: "If the command was a Workers Preview deployment, this will be the deployment ID within the Preview"

--- a/src/commandOutputParsing.ts
+++ b/src/commandOutputParsing.ts
@@ -4,9 +4,13 @@ import {
 	getOutputEntry,
 	OutputEntryDeployment,
 	OutputEntryPagesDeployment,
+	OutputEntryPreview,
 	OutputEntryVersionUpload,
 } from "./wranglerArtifactManager";
-import { createGitHubDeploymentAndJobSummary } from "./service/github";
+import {
+	createGitHubDeploymentAndJobSummary,
+	createPreviewGitHubDeploymentAndJobSummary,
+} from "./service/github";
 
 // fallback to trying to extract the deployment-url and pages-deployment-alias-url from stdout for wranglerVersion < 3.81.0
 function extractDeploymentUrlsFromStdout(stdOut: string): {
@@ -114,6 +118,32 @@ function handleVersionsUploadOutputEntry(
 	setOutput("deployment-url", versionsOutputEntry.preview_url);
 }
 
+async function handlePreviewOutputEntry(
+	config: WranglerActionConfig,
+	previewOutputEntry: OutputEntryPreview,
+) {
+	const previewUrl =
+		previewOutputEntry.preview_urls?.[0] ?? undefined;
+	const deploymentUrl =
+		previewOutputEntry.deployment_urls?.[0] ?? undefined;
+
+	// Set the primary deployment-url to the preview URL (stable branch URL)
+	setOutput("deployment-url", previewUrl);
+
+	// Set preview-specific outputs
+	setOutput("preview-url", previewUrl);
+	setOutput("preview-deployment-url", deploymentUrl);
+	setOutput("preview-name", previewOutputEntry.preview_name);
+	setOutput("preview-id", previewOutputEntry.preview_id);
+	setOutput("preview-deployment-id", previewOutputEntry.deployment_id);
+
+	// Create GitHub Deployment and Job Summary for the preview
+	await createPreviewGitHubDeploymentAndJobSummary(
+		config,
+		previewOutputEntry,
+	);
+}
+
 /**
  * If no wrangler output file found, log a message stating deployment-url will be unavailable for output.
  * @deprecated Use {@link handleVersionsOutputEntry} instead.
@@ -150,6 +180,17 @@ function handleDeprectatedStdoutParsing(
 		handleVersionsOutputCommand(config);
 		return;
 	}
+
+	// Check if this command is a preview deployment
+	if (command.startsWith("preview")) {
+		info(
+			config,
+			"Unable to find a WRANGLER_OUTPUT_DIR, preview outputs will be unavailable. Have you updated wrangler to the latest version?",
+		);
+		const { deploymentUrl } = extractDeploymentUrlsFromStdout(stdOut);
+		setOutput("deployment-url", deploymentUrl);
+		return;
+	}
 }
 
 export async function handleCommandOutputParsing(
@@ -175,6 +216,9 @@ export async function handleCommandOutputParsing(
 			break;
 		case "version-upload":
 			handleVersionsUploadOutputEntry(outputEntry);
+			break;
+		case "preview":
+			await handlePreviewOutputEntry(config, outputEntry);
 			break;
 	}
 }

--- a/src/commandOutputParsing.ts
+++ b/src/commandOutputParsing.ts
@@ -122,10 +122,8 @@ async function handlePreviewOutputEntry(
 	config: WranglerActionConfig,
 	previewOutputEntry: OutputEntryPreview,
 ) {
-	const previewUrl =
-		previewOutputEntry.preview_urls?.[0] ?? undefined;
-	const deploymentUrl =
-		previewOutputEntry.deployment_urls?.[0] ?? undefined;
+	const previewUrl = previewOutputEntry.preview_urls?.[0] ?? undefined;
+	const deploymentUrl = previewOutputEntry.deployment_urls?.[0] ?? undefined;
 
 	// Set the primary deployment-url to the preview URL (stable branch URL)
 	setOutput("deployment-url", previewUrl);
@@ -138,10 +136,7 @@ async function handlePreviewOutputEntry(
 	setOutput("preview-deployment-id", previewOutputEntry.deployment_id);
 
 	// Create GitHub Deployment and Job Summary for the preview
-	await createPreviewGitHubDeploymentAndJobSummary(
-		config,
-		previewOutputEntry,
-	);
+	await createPreviewGitHubDeploymentAndJobSummary(config, previewOutputEntry);
 }
 
 /**

--- a/src/service/github.ts
+++ b/src/service/github.ts
@@ -172,45 +172,44 @@ export async function createPreviewGitHubDeploymentAndJobSummary(
 		const githubBranch = env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME;
 		const environmentName = `preview: ${previewFields.preview_name}`;
 
-		const [createDeploymentRes, createSummaryRes] =
-			await Promise.allSettled([
-				(async () => {
-					const deployment = await octokit.rest.repos.createDeployment({
-						owner: context.repo.owner,
-						repo: context.repo.repo,
-						ref: githubBranch || context.ref,
-						auto_merge: false,
-						description: "Cloudflare Workers Preview",
-						required_contexts: [],
-						environment: environmentName,
-						production_environment: false,
-					});
+		const [createDeploymentRes, createSummaryRes] = await Promise.allSettled([
+			(async () => {
+				const deployment = await octokit.rest.repos.createDeployment({
+					owner: context.repo.owner,
+					repo: context.repo.repo,
+					ref: githubBranch || context.ref,
+					auto_merge: false,
+					description: "Cloudflare Workers Preview",
+					required_contexts: [],
+					environment: environmentName,
+					production_environment: false,
+				});
 
-					if (deployment.status !== 201) {
-						info(config, "Error creating GitHub deployment for preview");
-						return;
-					}
+				if (deployment.status !== 201) {
+					info(config, "Error creating GitHub deployment for preview");
+					return;
+				}
 
-					await octokit.rest.repos.createDeploymentStatus({
-						owner: context.repo.owner,
-						repo: context.repo.repo,
-						deployment_id: deployment.data.id,
-						environment: environmentName,
-						environment_url: previewUrl,
-						production_environment: false,
-						log_url: `https://dash.cloudflare.com/${config.CLOUDFLARE_ACCOUNT_ID}/workers/services/view/${previewFields.worker_name}`,
-						description: "Cloudflare Workers Preview",
-						state: "success",
-						auto_inactive: false,
-					});
-				})(),
-				createPreviewJobSummary({
-					previewName: previewFields.preview_name,
-					previewUrl,
-					deploymentUrl,
-					workerName: previewFields.worker_name,
-				}),
-			]);
+				await octokit.rest.repos.createDeploymentStatus({
+					owner: context.repo.owner,
+					repo: context.repo.repo,
+					deployment_id: deployment.data.id,
+					environment: environmentName,
+					environment_url: previewUrl,
+					production_environment: false,
+					log_url: `https://dash.cloudflare.com/${config.CLOUDFLARE_ACCOUNT_ID}/workers/services/view/${previewFields.worker_name}`,
+					description: "Cloudflare Workers Preview",
+					state: "success",
+					auto_inactive: false,
+				});
+			})(),
+			createPreviewJobSummary({
+				previewName: previewFields.preview_name,
+				previewUrl,
+				deploymentUrl,
+				workerName: previewFields.worker_name,
+			}),
+		]);
 
 		if (createDeploymentRes.status === "rejected") {
 			warn(config, "Creating Github Deployment for preview failed");

--- a/src/service/github.ts
+++ b/src/service/github.ts
@@ -2,7 +2,10 @@ import { summary } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 import { env } from "process";
 import { info, warn } from "../utils";
-import { OutputEntryPagesDeployment } from "../wranglerArtifactManager";
+import {
+	OutputEntryPagesDeployment,
+	OutputEntryPreview,
+} from "../wranglerArtifactManager";
 import { WranglerActionConfig } from "../wranglerAction";
 
 type Octokit = ReturnType<typeof getOctokit>;
@@ -123,6 +126,110 @@ export async function createGitHubDeploymentAndJobSummary(
 
 		if (createJobSummaryRes.status === "rejected") {
 			warn(config, "Creating Github Job summary failed");
+		}
+	}
+}
+
+export async function createPreviewJobSummary({
+	previewName,
+	previewUrl,
+	deploymentUrl,
+	workerName,
+}: {
+	previewName: string;
+	previewUrl?: string;
+	deploymentUrl?: string;
+	workerName: string | null;
+}) {
+	await summary
+		.addRaw(
+			`
+# Workers Preview Deployment
+
+| Name                    | Result |
+| ----------------------- | - |
+| **Worker:**             | ${workerName ?? "unknown"} |
+| **Preview:**            | ${previewName} |
+| **Preview URL**:        | ${previewUrl ?? "N/A"} |
+| **Deployment URL**:     | ${deploymentUrl ?? "N/A"} |
+  `,
+		)
+		.write();
+}
+
+/**
+ * Create GitHub deployment and job summary for a Workers Preview, if GITHUB_TOKEN is present
+ */
+export async function createPreviewGitHubDeploymentAndJobSummary(
+	config: WranglerActionConfig,
+	previewFields: OutputEntryPreview,
+) {
+	const previewUrl = previewFields.preview_urls?.[0];
+	const deploymentUrl = previewFields.deployment_urls?.[0];
+
+	if (config.GITHUB_TOKEN) {
+		const octokit = getOctokit(config.GITHUB_TOKEN);
+		const githubBranch = env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME;
+		const environmentName = `preview: ${previewFields.preview_name}`;
+
+		const [createDeploymentRes, createSummaryRes] =
+			await Promise.allSettled([
+				(async () => {
+					const deployment = await octokit.rest.repos.createDeployment({
+						owner: context.repo.owner,
+						repo: context.repo.repo,
+						ref: githubBranch || context.ref,
+						auto_merge: false,
+						description: "Cloudflare Workers Preview",
+						required_contexts: [],
+						environment: environmentName,
+						production_environment: false,
+					});
+
+					if (deployment.status !== 201) {
+						info(config, "Error creating GitHub deployment for preview");
+						return;
+					}
+
+					await octokit.rest.repos.createDeploymentStatus({
+						owner: context.repo.owner,
+						repo: context.repo.repo,
+						deployment_id: deployment.data.id,
+						environment: environmentName,
+						environment_url: previewUrl,
+						production_environment: false,
+						log_url: `https://dash.cloudflare.com/${config.CLOUDFLARE_ACCOUNT_ID}/workers/services/view/${previewFields.worker_name}`,
+						description: "Cloudflare Workers Preview",
+						state: "success",
+						auto_inactive: false,
+					});
+				})(),
+				createPreviewJobSummary({
+					previewName: previewFields.preview_name,
+					previewUrl,
+					deploymentUrl,
+					workerName: previewFields.worker_name,
+				}),
+			]);
+
+		if (createDeploymentRes.status === "rejected") {
+			warn(config, "Creating Github Deployment for preview failed");
+		}
+
+		if (createSummaryRes.status === "rejected") {
+			warn(config, "Creating Github Job summary for preview failed");
+		}
+	} else {
+		// Still create job summary even without GitHub token
+		try {
+			await createPreviewJobSummary({
+				previewName: previewFields.preview_name,
+				previewUrl,
+				deploymentUrl,
+				workerName: previewFields.worker_name,
+			});
+		} catch {
+			warn(config, "Creating Github Job summary for preview failed");
 		}
 	}
 }

--- a/src/service/github.ts
+++ b/src/service/github.ts
@@ -197,7 +197,9 @@ export async function createPreviewGitHubDeploymentAndJobSummary(
 					environment: environmentName,
 					environment_url: previewUrl,
 					production_environment: false,
-					log_url: `https://dash.cloudflare.com/${config.CLOUDFLARE_ACCOUNT_ID}/workers/services/view/${previewFields.worker_name}`,
+					log_url: previewFields.worker_name
+						? `https://dash.cloudflare.com/${config.CLOUDFLARE_ACCOUNT_ID}/workers/services/view/${previewFields.worker_name}`
+						: `https://dash.cloudflare.com/${config.CLOUDFLARE_ACCOUNT_ID}/workers`,
 					description: "Cloudflare Workers Preview",
 					state: "success",
 					auto_inactive: false,

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -363,9 +363,7 @@ async function wranglerCommands(
 
 			if (
 				config["VARS"].length &&
-				(command.startsWith("deploy") ||
-					command.startsWith("publish") ||
-					command.startsWith("preview")) &&
+				(command.startsWith("deploy") || command.startsWith("publish")) &&
 				!command.includes("--var")
 			) {
 				args.push("--var");

--- a/src/wranglerAction.ts
+++ b/src/wranglerAction.ts
@@ -363,7 +363,9 @@ async function wranglerCommands(
 
 			if (
 				config["VARS"].length &&
-				(command.startsWith("deploy") || command.startsWith("publish")) &&
+				(command.startsWith("deploy") ||
+					command.startsWith("publish") ||
+					command.startsWith("preview")) &&
 				!command.includes("--var")
 			) {
 				args.push("--var");

--- a/src/wranglerArtifactManager.test.ts
+++ b/src/wranglerArtifactManager.test.ts
@@ -179,5 +179,39 @@ describe("wranglerArtifactsManager", () => {
 				});
 			});
 		});
+
+		describe("OutputEntryPreview", async () => {
+			it("Returns only preview output from wrangler artifacts", async () => {
+				mockfs({
+					testOutputDir: {
+						"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+						{"version": 1, "type":"wrangler-session", "wrangler_version":"4.34.0", "command_line_args":["preview", "--json"], "log_file_path": "/here"}
+						{"version": 1, "type":"preview", "worker_name":"example-worker", "preview_id":"preview-id", "preview_name":"feature-branch", "preview_slug":"feature-branch", "preview_urls":["https://feature-branch.example-worker.cloudflare.app"], "deployment_id":"deployment-id", "deployment_urls":["https://deployment-id.example-worker.cloudflare.app"]}`,
+						"not-wrangler-output.json": "test",
+					},
+				});
+
+				const artifact = await getOutputEntry("./testOutputDir");
+				if (artifact?.type !== "preview") {
+					throw new Error(`Unexpected type ${artifact?.type}`);
+				}
+
+				expect(artifact).toEqual({
+					version: 1,
+					type: "preview",
+					worker_name: "example-worker",
+					preview_id: "preview-id",
+					preview_name: "feature-branch",
+					preview_slug: "feature-branch",
+					preview_urls: [
+						"https://feature-branch.example-worker.cloudflare.app",
+					],
+					deployment_id: "deployment-id",
+					deployment_urls: [
+						"https://deployment-id.example-worker.cloudflare.app",
+					],
+				});
+			});
+		});
 	});
 });

--- a/src/wranglerArtifactManager.test.ts
+++ b/src/wranglerArtifactManager.test.ts
@@ -62,32 +62,32 @@ describe("wranglerArtifactsManager", () => {
 					deployment_id: "123",
 					alias: "test.com",
 				});
-			}),
-				it("Skips artifact entries that are not parseable", async () => {
-					mockfs({
-						testOutputDir: {
-							"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+			});
+			it("Skips artifact entries that are not parseable", async () => {
+				mockfs({
+					testOutputDir: {
+						"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
 						this line is invalid json.
 						{"version": 1, "type":"pages-deploy-detailed", "pages_project": "project", "environment":"production", "alias":"test.com", "deployment_id": "123", "url":"url.com"}`,
-							"not-wrangler-output.json": "test",
-						},
-					});
-
-					const artifact = await getOutputEntry("./testOutputDir");
-					if (artifact?.type !== "pages-deploy-detailed") {
-						throw new Error(`Unexpected type ${artifact?.type}`);
-					}
-
-					expect(artifact).toEqual({
-						version: 1,
-						type: "pages-deploy-detailed",
-						pages_project: "project",
-						url: "url.com",
-						environment: "production",
-						deployment_id: "123",
-						alias: "test.com",
-					});
+						"not-wrangler-output.json": "test",
+					},
 				});
+
+				const artifact = await getOutputEntry("./testOutputDir");
+				if (artifact?.type !== "pages-deploy-detailed") {
+					throw new Error(`Unexpected type ${artifact?.type}`);
+				}
+
+				expect(artifact).toEqual({
+					version: 1,
+					type: "pages-deploy-detailed",
+					pages_project: "project",
+					url: "url.com",
+					environment: "production",
+					deployment_id: "123",
+					alias: "test.com",
+				});
+			});
 		});
 
 		describe("OutputEntryDeployment", async () => {
@@ -111,28 +111,28 @@ describe("wranglerArtifactsManager", () => {
 					type: "deploy",
 					targets: ["https://example.com"],
 				});
-			}),
-				it("Skips artifact entries that are not parseable", async () => {
-					mockfs({
-						testOutputDir: {
-							"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+			});
+			it("Skips artifact entries that are not parseable", async () => {
+				mockfs({
+					testOutputDir: {
+						"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
 						this line is invalid json.
 						{"version": 1, "type":"deploy", "targets": ["https://example.com"]}`,
-							"not-wrangler-output.json": "test",
-						},
-					});
-
-					const artifact = await getOutputEntry("./testOutputDir");
-					if (artifact?.type !== "deploy") {
-						throw new Error(`Unexpected type ${artifact?.type}`);
-					}
-
-					expect(artifact).toEqual({
-						version: 1,
-						type: "deploy",
-						targets: ["https://example.com"],
-					});
+						"not-wrangler-output.json": "test",
+					},
 				});
+
+				const artifact = await getOutputEntry("./testOutputDir");
+				if (artifact?.type !== "deploy") {
+					throw new Error(`Unexpected type ${artifact?.type}`);
+				}
+
+				expect(artifact).toEqual({
+					version: 1,
+					type: "deploy",
+					targets: ["https://example.com"],
+				});
+			});
 		});
 
 		describe("OutputEntryVersionUpload", async () => {
@@ -156,28 +156,28 @@ describe("wranglerArtifactsManager", () => {
 					type: "version-upload",
 					preview_url: "https://example.com",
 				});
-			}),
-				it("Skips artifact entries that are not parseable", async () => {
-					mockfs({
-						testOutputDir: {
-							"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
+			});
+			it("Skips artifact entries that are not parseable", async () => {
+				mockfs({
+					testOutputDir: {
+						"wrangler-output-2024-10-17_18-48-40_463-2e6e83.json": `
 						this line is invalid json.
 						{"version": 1, "type":"version-upload", "preview_url": "https://example.com"}`,
-							"not-wrangler-output.json": "test",
-						},
-					});
-
-					const artifact = await getOutputEntry("./testOutputDir");
-					if (artifact?.type !== "version-upload") {
-						throw new Error(`Unexpected type ${artifact?.type}`);
-					}
-
-					expect(artifact).toEqual({
-						version: 1,
-						type: "version-upload",
-						preview_url: "https://example.com",
-					});
+						"not-wrangler-output.json": "test",
+					},
 				});
+
+				const artifact = await getOutputEntry("./testOutputDir");
+				if (artifact?.type !== "version-upload") {
+					throw new Error(`Unexpected type ${artifact?.type}`);
+				}
+
+				expect(artifact).toEqual({
+					version: 1,
+					type: "version-upload",
+					preview_url: "https://example.com",
+				});
+			});
 		});
 	});
 });

--- a/src/wranglerArtifactManager.ts
+++ b/src/wranglerArtifactManager.ts
@@ -50,11 +50,33 @@ const OutputEntryVersionUpload = OutputEntryBase.merge(
 	}),
 );
 
+export type OutputEntryPreview = z.infer<typeof OutputEntryPreview>;
+const OutputEntryPreview = OutputEntryBase.merge(
+	z.object({
+		type: z.literal("preview"),
+		/** The name of the Worker */
+		worker_name: z.string().nullable(),
+		/** The ID of the Preview resource */
+		preview_id: z.string(),
+		/** The human-readable name of the Preview (typically the branch name) */
+		preview_name: z.string(),
+		/** The URL-safe slug of the Preview */
+		preview_slug: z.string(),
+		/** URLs associated with the Preview (e.g. branch preview URL) */
+		preview_urls: z.array(z.string()).optional(),
+		/** The ID of the deployment within this Preview */
+		deployment_id: z.string(),
+		/** Immutable URLs for this specific deployment */
+		deployment_urls: z.array(z.string()).optional(),
+	}),
+);
+
 export type SupportedOutputEntry = z.infer<typeof SupportedOutputEntry>;
 const SupportedOutputEntry = z.discriminatedUnion("type", [
 	OutputEntryPagesDeployment,
 	OutputEntryDeployment,
 	OutputEntryVersionUpload,
+	OutputEntryPreview,
 ]);
 
 /**


### PR DESCRIPTION
## What

Adds support for `wrangler preview` in `wrangler-action`. Preview commands now parse Wrangler Preview artifacts, expose Preview-specific outputs, and can create GitHub Deployments and job summaries when `gitHubToken` is provided.

The README documents the direct Wrangler workflow first, so users can copy plain GitHub Actions YAML without taking a dependency on this action. It then shows the `wrangler-action` wrapper for users who want action outputs, GitHub Deployments, and job summaries.

## Changes

- Adds a Zod schema for Wrangler Preview artifacts.
- Parses `preview` command output and sets Preview outputs.
- Adds fallback stdout parsing for Preview commands.
- Creates non-production GitHub Deployments for Previews when `gitHubToken` is provided.
- Renders a Workers Preview job summary.
- Extends `--var` auto-injection to `preview` commands.
- Adds README guidance for plain `npx wrangler preview --json`, `wrangler-action`, and deeper automation examples.
- Adds a minor changeset so this ships in the next `wrangler-action` v4 release.

## Outputs

| Output | Description |
| --- | --- |
| `deployment-url` | Stable Preview URL, kept compatible with existing deployment URL usage |
| `preview-url` | Stable Preview URL for the branch or Preview name |
| `preview-deployment-url` | Immutable URL for the specific Preview deployment |
| `preview-name` | Preview name |
| `preview-id` | Preview resource ID |
| `preview-deployment-id` | Deployment ID within the Preview |

## Example

Users can run Wrangler directly:

```yaml
name: Preview

on: [pull_request]

jobs:
  preview:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v6
      - run: npx wrangler preview --json
        env:
          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
```

Or use `wrangler-action` when they want Preview outputs, GitHub Deployments, and the job summary:

```yaml
- uses: actions/checkout@v6
- id: preview
  uses: cloudflare/wrangler-action@v4
  with:
    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
    command: preview
    gitHubToken: ${{ secrets.GITHUB_TOKEN }}
```

## Verification

Local verification passes:

- `npm run build`
- `npm test -- --run`
- `npm run check`

The `wrangler_action_self_testing` PR check currently fails at a live deployment fixture because this PR run does not have access to the Cloudflare secrets required by that workflow. The build, unit tests, and formatting steps in that same check pass before the secrets-backed fixture runs.
